### PR TITLE
[#131375099] Allow customise the settings for the target concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ This repository contains the scripts and Terraform configurations required to se
 
 A pipeline should be created for each Bosh release this repository is currently building releases for. The `build-dev-release` jobs should trigger when pull requests are raised against the Bosh release's repository. The `build-final-release` job should trigger when new commits are added to the branch used to build final releases.
 
+You can override some variables to customise the deployment:
+ * `BRANCH` current branch to pull and use. e.g. `BRANCH=$(git rev-parse --abbrev-ref HEAD)`
+ * `CONCOURSE_URL`, `CONCOURSE_ATC_PASSWORD`: to point to a different concourse with the given credentials.
+ * `STATE_BUCKET_NAME`, `RELEASES_BUCKET_NAME`: use alternative state and releases buckets.
+

--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -43,14 +43,14 @@ resources:
   - name: bosh-release-tarballs
     type: s3-iam
     source:
-      bucket: {{bucket_name}}
+      bucket: {{releases_bucket_name}}
       region_name: {{aws_region}}
       regexp: ([a-z0-9]+).tgz
 
   - name: bosh-release-version
     type: semver-iam
     source:
-      bucket: {{bucket_name}}
+      bucket: {{releases_bucket_name}}
       region_name: {{aws_region}}
       key: {{version_file}}
       initial_version: 0.1.0
@@ -80,7 +80,7 @@ jobs:
           outputs:
             - name: bosh-release-tarballs
           params:
-            BUCKET: {{bucket_name}}
+            BUCKET: {{releases_bucket_name}}
             REGION: {{aws_region}}
             NAME: {{boshrelease_name}}
           run:
@@ -145,7 +145,7 @@ jobs:
           outputs:
             - name: bosh-release-tarballs
           params:
-            BUCKET: {{bucket_name}}
+            BUCKET: {{releases_bucket_name}}
             REGION: {{aws_region}}
             NAME: {{boshrelease_name}}
           run:

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -14,7 +14,7 @@ resources:
   - name: pipeline-trigger
     type: semver-iam
     source:
-      bucket: {{state_bucket}}
+      bucket: {{state_bucket_name}}
       region_name: {{aws_region}}
       key: {{pipeline_trigger_file}}
 
@@ -27,7 +27,7 @@ resources:
   - name: release-ci-tfstate
     type: s3-iam
     source:
-      bucket: {{state_bucket}}
+      bucket: {{state_bucket_name}}
       region_name: {{aws_region}}
       versioned_file: release-ci.tfstate
 
@@ -59,6 +59,7 @@ jobs:
             - name: updated-release-ci-tfstate
           params:
             TF_VAR_deploy_env: {{deploy_env}}
+            TF_VAR_releases_bucket_name: {{releases_bucket_name}}
           run:
             path: sh
             args:

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -14,7 +14,7 @@ resources:
   - name: pipeline-trigger
     type: semver-iam
     source:
-      bucket: {{state_bucket}}
+      bucket: {{state_bucket_name}}
       region_name: {{aws_region}}
       key: {{pipeline_trigger_file}}
 
@@ -27,7 +27,7 @@ resources:
   - name: release-ci-tfstate
     type: s3-iam
     source:
-      bucket: {{state_bucket}}
+      bucket: {{state_bucket_name}}
       region_name: {{aws_region}}
       versioned_file: release-ci.tfstate
 
@@ -53,6 +53,8 @@ jobs:
             CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
             CONCOURSE_URL: {{concourse_url}}
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
+            STATE_BUCKET_NAME: {{state_bucket_name}}
+            RELEASES_BUCKET_NAME: {{releases_bucket_name}}
           run:
             path: sh
             args:
@@ -93,7 +95,7 @@ jobs:
               - -e
               - -c
               - |
-                paas-release-ci/scripts/s3init.sh {{state_bucket}} release-ci.tfstate paas-release-ci/pipelines/init_files/terraform.tfstate.tpl
+                paas-release-ci/scripts/s3init.sh {{state_bucket_name}} release-ci.tfstate paas-release-ci/pipelines/init_files/terraform.tfstate.tpl
 
   - name: terraform
     plan:
@@ -118,6 +120,7 @@ jobs:
             - name: updated-release-ci-tfstate
           params:
             TF_VAR_deploy_env: {{deploy_env}}
+            TF_VAR_releases_bucket_name: {{releases_bucket_name}}
           run:
             path: sh
             args:
@@ -156,6 +159,8 @@ jobs:
             CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
             CONCOURSE_URL: {{concourse_url}}
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
+            STATE_BUCKET_NAME: {{state_bucket_name}}
+            RELEASES_BUCKET_NAME: {{releases_bucket_name}}
           run:
             path: sh
             args:

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -51,6 +51,7 @@ jobs:
             BRANCH: {{branch_name}}
             MAKEFILE_ENV_TARGET: {{makefile_env_target}}
             CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
+            CONCOURSE_URL: {{concourse_url}}
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
           run:
             path: sh
@@ -153,6 +154,7 @@ jobs:
             BRANCH: {{branch_name}}
             MAKEFILE_ENV_TARGET: {{makefile_env_target}}
             CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
+            CONCOURSE_URL: {{concourse_url}}
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
           run:
             path: sh

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -16,6 +16,7 @@ deploy_env: ${DEPLOY_ENV}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
+concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 aws_account: ${AWS_ACCOUNT}
 bucket_name: gds-paas-${DEPLOY_ENV}-releases

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -19,7 +19,7 @@ concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 aws_account: ${AWS_ACCOUNT}
-bucket_name: gds-paas-${DEPLOY_ENV}-releases
+releases_bucket_name: ${RELEASES_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases}
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 github_status_context: ${DEPLOY_ENV}/status
 # move

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -15,7 +15,8 @@ makefile_env_target: ${MAKEFILE_ENV_TARGET}
 self_update_pipeline: ${SELF_UPDATE_PIPELINE:-true}
 aws_account: ${AWS_ACCOUNT}
 deploy_env: ${DEPLOY_ENV}
-state_bucket: gds-paas-${DEPLOY_ENV}-state
+state_bucket_name: ${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}
+releases_bucket_name: ${RELEASES_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -19,6 +19,7 @@ state_bucket: gds-paas-${DEPLOY_ENV}-state
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
+concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 pipeline_trigger_file: ${pipeline_name}.trigger
 github_access_token: ${GITHUB_ACCESS_TOKEN}

--- a/scripts/fly_sync_and_login.sh
+++ b/scripts/fly_sync_and_login.sh
@@ -10,7 +10,10 @@ set -euo pipefail
 
 FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
 echo "Downloading fly command..."
-curl "$FLY_CMD_URL" -# -L -f -k -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
+if [ -f "$FLY_CMD" ]; then
+  timestamp_flag=1
+fi
+curl "$FLY_CMD_URL" -# -L -f -k ${timestamp_flag:+-z "$FLY_CMD"} -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
 chmod +x "$FLY_CMD"
 
 echo "Doing fly login"

--- a/terraform/buckets-boshreleases.tf
+++ b/terraform/buckets-boshreleases.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "gds-paas-releases" {
-  bucket        = "${format("gds-paas-%s-releases", var.deploy_env)}"
+  bucket        = "${var.releases_bucket_name}"
   acl           = "public-read"
   force_destroy = "true"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,3 +15,7 @@ variable "deploy_env" {}
 variable "region" {
   default = "eu-west-1"
 }
+
+variable "releases_bucket_name" {
+  description = "Name of the bucket to store the created releases"
+}


### PR DESCRIPTION
[#131375099 Check health of cell components](https://www.pivotaltracker.com/story/show/131375099)

What?
-----

I want to extend this project to include a new bosh-release, but I don't want to have to deploy a complete concourse and bosh release to test the changes. Instead, I want to be able to use my concourse from paas-cf.

This PR adds the capacity to override the concourse url and buckets to allow so.

How to test?
------------

Code sanity check.

you can try against your own concourse in paas-cf by doing:

```
export DEPLOY_ENV=....
export CONCOURSE_ATC_PASSWORD=.....

STATE_BUCKET=${DEPLOY_ENV}-state \
RELEASES_BUCKET_NAME=${DEPLY_ENV}-releases-state \
BRANCH=$(git rev-parse --abbrev-ref HEAD) \
CONCOURSE_URL=https://deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital \
make dev pipelines
```

Check that the `setup` pipeline works

Who?
----

Anyone but @keymon