### PR TITLE
[#131375099] Add datadog-for-cloudfoundry to the list of bosh-releases to build

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -45,3 +45,4 @@ setup_release_pipeline() {
 }
 
 setup_release_pipeline rds-broker alphagov/paas-rds-broker-boshrelease master
+setup_release_pipeline datadog-for-cloudfoundry alphagov/paas-datadog-for-cloudfoundry-boshrelease master

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -31,13 +31,17 @@ version_file: ${boshrelease_name}.version
 EOF
 }
 
-boshrelease_name=rds-broker
-github_repo=alphagov/paas-rds-broker-boshrelease
-final_release_branch=master
+setup_release_pipeline() {
+  boshrelease_name="$1"
+  github_repo="$2"
+  final_release_branch="$3"
 
-generate_vars_file > /dev/null # Check for missing vars
+  generate_vars_file > /dev/null # Check for missing vars
 
-bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
-  "${boshrelease_name}" \
-  "${PIPELINES_DIR}/build-release.yml" \
-  <(generate_vars_file)
+  bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
+    "${boshrelease_name}" \
+    "${PIPELINES_DIR}/build-release.yml" \
+    <(generate_vars_file)
+}
+
+setup_release_pipeline rds-broker alphagov/paas-rds-broker-boshrelease master


### PR DESCRIPTION
[#131375099 Check health of cell components](https://www.pivotaltracker.com/story/show/131375099)

What?
-----

We are extending https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/ to monitor the cell components, and we want to add it to these build server.

In this PR we also refactor the script to make it easier to add new releases.

Dependencies
------------

~~This PR is build over the PR https://github.com/alphagov/paas-release-ci/pull/2 which should be merged first. That PR allows test with the paas-cf concourse.~~  (merged)

How to review?
--------------

Code check.

Then you can test creating a build server:

```
export DEPLOY_ENV=....
BRANCH=$(git rev-parse --abbrev-ref HEAD) \
make dev pipelines
```

or using the paas-cf from concourse:

```
export DEPLOY_ENV=....
export CONCOURSE_ATC_PASSWORD=.....

STATE_BUCKET=${DEPLOY_ENV}-state \
RELEASES_BUCKET_NAME=${DEPLY_ENV}-releases-state \
BRANCH=$(git rev-parse --abbrev-ref HEAD) \
CONCOURSE_URL=https://deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital \
make dev pipelines
```

Then run the setup pipeline. Both releases should have their own pipeline after. You can run the one from datadog-for-cloudfoundry.

Who?
----

Anyone but @keymon