### PR TITLE
[#132745311] Add our release paas-haproxy-release

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -47,3 +47,4 @@ setup_release_pipeline() {
 setup_release_pipeline rds-broker alphagov/paas-rds-broker-boshrelease master
 setup_release_pipeline datadog-for-cloudfoundry alphagov/paas-datadog-for-cloudfoundry-boshrelease master
 setup_release_pipeline logsearch-for-cloudfoundry alphagov/paas-logsearch-for-cloudfoundry gds_master
+setup_release_pipeline paas-haproxy alphagov/paas-haproxy-release master


### PR DESCRIPTION
I add this in the scope of https://www.pivotaltracker.com/story/show/132745311 but the story is not being played now. It is only for cross reference.

What?
----

I add this project to the concourse ci as I am working on https://github.com/alphagov/paas-haproxy-release/pull/7

The release is ours (no fork) and it is called paas-haproxy.

How to review?
-----------

check it makes sense

who?
---

Anyone but @keymon