### PR TITLE
[#135320595] Use upstream pull request resource

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -13,7 +13,7 @@ resource_types:
   - name: pull-request
     type: docker-image
     source:
-      repository: governmentpaas/pullrequest-resource
+      repository: jtarchie/pr
 
   - name: s3-iam
     type: docker-image
@@ -32,7 +32,7 @@ resources:
       repo: {{github_repo}}
       access_token: {{github_access_token}}
       every: true
-      disallow_forks: true
+      disable_forks: true
 
   - name: bosh-release-repo
     type: git


### PR DESCRIPTION
## What

[#135320595 - Rework Pull requests resource PR](https://www.pivotaltracker.com/story/show/135320595)

The upstream author has accepted the new functionality to prevent
pull requests from forked repositories from generating new versions
of the resource. This will stop untrusted code being pulled into our
pipeline and potentially executing arbitrary code.

The version with this functionality is tagged as v20[1]

[1] https://github.com/jtarchie/pullrequest-resource/tree/v20

## How to review

Assert that pull requests from forks do not trigger the build of Bosh releases in our build pipeline.

* Deploy a build environment using paas-bootstrap. If you haven't done that before we can have a chat about how it is done. The key part is not setting `DEPLOY_ENV` to the same as your CF deployment.
* Configure its pipelines using this branch.
* Raise two pull requests for any of the Bosh releases we build in the pipeline: one from a fork, one internally.
    * The internal one should trigger the build-dev-release job.
    * The pull request from the fork should **NOT** trigger the build-dev-release job

## Who

Anyone but me