### PR TITLE
[CLEANUP] Leftover removal

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -74,7 +74,6 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
-              tag: 130188061_add_bash_to_boshcli
           inputs:
             - name: bosh-release-pr
           outputs:


### PR DESCRIPTION
## What

I think the `130188061_add_bash_to_boshcli` tag was merged here unintentionally and was a leftover from testing.

## How to test

Make sure that it looks sane.

## Who

Not me