### PR TITLE
[#136353551] Deploy tech docs application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ before_install:
     unzip -o terraform_${TF_VERSION}_linux_amd64.zip -d ~/bin
     rm terraform_${TF_VERSION}_linux_amd64.zip
   - pip install --user yamllint
+  - eval "$(gimme 1.6)"
+  - export GOPATH=$HOME/gopath
+  - export PATH=$HOME/gopath/bin:$PATH
+  - go get github.com/onsi/ginkgo/ginkgo
+  - go get github.com/onsi/gomega/...
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ ci: globals ## Work on the ci account
 	$(eval export CONCOURSE_ATC_PASSWORD_PASS_FILE=ci_deployments/build/concourse_password)
 	@true
 
+.PHONY: upload-cf-cli-secrets
+upload-cf-cli-secrets: check-env-vars ## Decrypt and upload CF CLI credentials to S3
+	$(eval export CF_CLI_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/ci))
+	$(if ${CF_CLI_PASSWORD_STORE_DIR},,$(error Must pass CF_CLI_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${CF_CLI_PASSWORD_STORE_DIR}),,$(error Password store ${CF_CLI_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-cf-cli-secrets.sh
+
 .PHONY: pipelines
 pipelines: ## Upload setup pipelines to concourse
 	@scripts/deploy-setup-pipelines.sh

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ dev: globals check-env-vars ## Work on the dev account
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export CF_API_SECURE=--skip-ssl-validation)
 	@true
 
 ci: globals ## Work on the ci account
@@ -23,6 +24,7 @@ ci: globals ## Work on the ci account
 	$(eval export ENABLE_AUTO_TRIGGER=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export CONCOURSE_ATC_PASSWORD_PASS_FILE=ci_deployments/build/concourse_password)
+	$(eval export CF_API=https://api.cloud.service.gov.uk)
 	@true
 
 .PHONY: upload-cf-cli-secrets
@@ -41,6 +43,10 @@ pipelines: ## Upload setup pipelines to concourse
 boshrelease-pipelines: ## Upload boshrelease pipelines to concourse
 	@scripts/build-boshrelease-pipelines.sh
 
+.PHONY: app-deployment-pipelines
+app-deployment-pipelines: ## Upload app deployment pipelines to concourse
+	@scripts/build-app-deployment-pipelines.sh
+
 showenv: ## Display environment information
 	@scripts/environment.sh
 
@@ -48,7 +54,11 @@ showenv: ## Display environment information
 ## Testing tasks
 
 .PHONY: test
-test: lint_shellcheck lint_terraform lint_yaml lint_concourse
+test: spec lint_shellcheck lint_terraform lint_yaml lint_concourse
+
+.PHONY: spec
+spec:
+	cd scripts && go test
 
 .PHONY: lint_shellcheck
 lint_shellcheck:

--- a/app-deploy.d/tech-docs
+++ b/app-deploy.d/tech-docs
@@ -1,0 +1,6 @@
+APP_NAME="tech-docs"
+APP_REPOSITORY="https://github.com/alphagov/paas-tech-docs.git"
+APP_BRANCH="master"
+APP_DOCKER_IMAGE="governmentpaas/tech-docs"
+APP_CF_ORG="govuk-paas"
+APP_CF_SPACE="docs"

--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -1,0 +1,111 @@
+---
+resources:
+  - name: {{app_name}}
+    type: git
+    source:
+      uri: {{app_github_repo_uri}}
+      branch: {{app_repository_branch}}
+
+jobs:
+  - name: test
+    plan:
+      - get: {{app_name}}
+        trigger: true
+      - task: test
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: {{app_deployment_docker_image}}
+          inputs:
+            - name: {{app_name}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                if [ ! -f {{app_name}}/release/test ]; then
+                  echo No script found at {{app_name}}/release/test, tests disabled
+                  exit 0
+                fi
+                echo Testing with script {{app_name}}/release/test
+                cd {{app_name}} && ./release/test
+
+  - name: deploy
+    plan:
+      - get: {{app_name}}
+        passed: ['test']
+        trigger: true
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: {{app_deployment_docker_image}}
+          inputs:
+            - name: {{app_name}}
+          outputs:
+            - name: files-to-push
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                if [ ! -f {{app_name}}/release/build ]; then
+                  echo No script found at {{app_name}}/release/build, build disabled
+                  exit 0
+                fi
+                echo Building with script {{app_name}}/release/build...
+                (cd {{app_name}} && ./release/build)
+                echo Copying files to destination...
+                cp -pr {{app_name}}/* files-to-push/
+                ls -l files-to-push
+
+      - task: push
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-cli
+          inputs:
+            - name: files-to-push
+          params:
+            CF_API: {{cf_api}}
+            CF_API_SECURE: {{cf_api_secure}}
+            CF_USER: {{cf_user}}
+            CF_PASSWORD: {{cf_password}}
+            CF_ORG: {{cf_org}}
+            CF_SPACE: {{cf_space}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - -x
+              - |
+                echo Logging on to Cloudfoundry...
+                cf login "${CF_API_SECURE:-}" -a "${CF_API}" -u "${CF_USER}" \
+                -p "${CF_PASSWORD}" -o "${CF_ORG}" -s "${CF_SPACE}"
+
+                cd files-to-push
+                if [ -f release/push ]; then
+                  echo Pushing to Cloudfoundry with script {{app_name}}/release/push...
+                  ./release/push
+
+                else
+                  echo No script found at {{app_name}}/release/push, using default push
+
+                  echo Deploy with zero downtime
+                  cf blue-green-deploy {{app_name}}
+
+                  echo Delete left over app
+                  cf delete -f {{app_name}}-old
+                fi

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -55,6 +55,7 @@ jobs:
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
             STATE_BUCKET_NAME: {{state_bucket_name}}
             RELEASES_BUCKET_NAME: {{releases_bucket_name}}
+            CF_API: {{cf_api}}
           run:
             path: sh
             args:
@@ -135,7 +136,7 @@ jobs:
           put: release-ci-tfstate
           params:
             file: updated-release-ci-tfstate/release-ci.tfstate
-  - name: boshrelease-pipelines
+  - name: dynamic-pipelines
     plan:
       - aggregate:
           - get: pipeline-trigger
@@ -161,6 +162,10 @@ jobs:
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
             STATE_BUCKET_NAME: {{state_bucket_name}}
             RELEASES_BUCKET_NAME: {{releases_bucket_name}}
+            CF_API: {{cf_api}}
+            CF_API_SECURE: {{cf_api_secure}}
+            CF_USER: {{cf_user}}
+            CF_PASSWORD: {{cf_password}}
           run:
             path: sh
             args:
@@ -169,3 +174,4 @@ jobs:
               - -c
               - |
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" boshrelease-pipelines
+                make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" app-deployment-pipelines

--- a/scripts/build-app-deployment-pipelines.sh
+++ b/scripts/build-app-deployment-pipelines.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eu
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")" && pwd)
+PIPELINES_DIR="${SCRIPTS_DIR}/../pipelines"
+
+# shellcheck disable=SC2091
+$("${SCRIPTS_DIR}/environment.sh")
+"${SCRIPTS_DIR}/fly_sync_and_login.sh"
+
+generate_vars_file() {
+   cat <<EOF
+---
+app_name: ${APP_NAME}
+app_github_repo_uri: ${APP_REPOSITORY}
+app_repository_branch: ${APP_BRANCH}
+app_deployment_docker_image: ${APP_DOCKER_IMAGE}
+cf_api: ${CF_API}
+cf_api_secure: ${CF_API_SECURE:-}
+cf_user: ${CF_USER}
+cf_password: ${CF_PASSWORD}
+cf_org: ${CF_ORG:-${APP_CF_ORG}}
+cf_space: ${CF_SPACE:-${APP_CF_SPACE}}
+EOF
+}
+
+for app in ${SCRIPTS_DIR}/../app-deploy.d/* ; do
+  (
+    # shellcheck source=/dev/null
+    . "${app}"
+
+    generate_vars_file > /dev/null # Check for missing vars
+
+    bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
+    "${APP_NAME}" \
+    "${PIPELINES_DIR}/deploy-app.yml" \
+    <(generate_vars_file)
+  )
+done

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -22,11 +22,7 @@ FLY_CMD="${FLY_DIR}/fly"
 
 CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER:-admin}
 if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-  if [ -n "${CONCOURSE_ATC_PASSWORD_PASS_FILE:-}" ]; then
-    CONCOURSE_ATC_PASSWORD=$(pass "${CONCOURSE_ATC_PASSWORD_PASS_FILE}")
-  else
-    CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")
-  fi
+  CONCOURSE_ATC_PASSWORD=$(scripts/val_from_yaml.rb secrets.concourse_atc_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
 fi
 
 if [ -z "${GITHUB_ACCESS_TOKEN:-}" ]; then

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -29,6 +29,11 @@ if [ -z "${GITHUB_ACCESS_TOKEN:-}" ]; then
   GITHUB_ACCESS_TOKEN=$(pass github.com/release_ci_pr_status_token)
 fi
 
+CF_USER=${CF_USER:-admin}
+if [ -z "${CF_PASSWORD:-}" ]; then
+  CF_PASSWORD=$(scripts/val_from_yaml.rb secrets.cf_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" -))
+fi
+
 cat <<EOF
 export AWS_ACCOUNT=${AWS_ACCOUNT}
 export DEPLOY_ENV=${DEPLOY_ENV}
@@ -38,4 +43,6 @@ export CONCOURSE_URL=${CONCOURSE_URL}
 export GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN}
 export FLY_CMD=${FLY_CMD}
 export FLY_TARGET=${FLY_TARGET}
+export CF_USER=${CF_USER}
+export CF_PASSWORD=${CF_PASSWORD}
 EOF

--- a/scripts/scripts_suite_test.go
+++ b/scripts/scripts_suite_test.go
@@ -1,0 +1,13 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestScripts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scripts Suite")
+}

--- a/scripts/upload-cf-cli-secrets.sh
+++ b/scripts/upload-cf-cli-secrets.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${CF_CLI_PASSWORD_STORE_DIR}
+
+if [ -n "${CF_USER:-}" ]; then
+  cf_user="${CF_USER}"
+else
+  cf_user=$(pass "${AWS_ACCOUNT}_deployments/${DEPLOY_ENV}/cf_app_deployer_user")
+fi
+if [ -n "${CF_PASSWORD:-}" ]; then
+  cf_password="${CF_PASSWORD}"
+else
+  cf_password=$(pass "${AWS_ACCOUNT}_deployments/${DEPLOY_ENV}/cf_app_deployer_password")
+fi
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+secrets:
+  cf_user: ${cf_user}
+  cf_password: ${cf_password}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml"

--- a/scripts/val_from_yaml.rb
+++ b/scripts/val_from_yaml.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require 'yaml'
+
+class PropertyTree
+  def initialize(tree)
+    @tree = tree
+  end
+
+  def self.load_yaml(yaml_string)
+    PropertyTree.new(YAML.load(yaml_string))
+  end
+
+  def recursive_get(tree, key_array)
+    return tree if key_array.empty?
+    current_key, *next_keys = key_array
+
+    next_level = case tree
+                 when Hash
+                   tree[current_key]
+                 when Array
+                   if /\A[-+]?\d+\z/ === current_key # If the key is an int, access by index
+                     tree[current_key.to_i]
+                   else # if not, search for a element with `name: current_key`
+                     tree.select { |x| x.is_a?(Hash) && x['name'] == current_key }.first
+                   end
+                 end
+    if not next_level.nil?
+      recursive_get(next_level, next_keys)
+    end
+  end
+
+  def get(key)
+    key_array = key.split('.')
+    self.recursive_get(@tree, key_array)
+  end
+
+  def [](key)
+    self.get(key)
+  end
+end
+
+if __FILE__ == $0 # Only execute if called directly as command
+  key = ARGV[0] || abort("Usage: #{$PROGRAM_NAME} <key.dot.delimited> [input.yml]")
+
+  property_tree = if ARGV[1]
+                    PropertyTree.load_yaml(File.open(ARGV[1]).read)
+                  else
+                    PropertyTree.load_yaml(STDIN.load)
+                  end
+
+  val = property_tree[key]
+  abort "Unable to find key: #{key}" if val.nil?
+
+  if val.is_a?(Array) || val.is_a?(Hash)
+    puts YAML.dump(val)
+  else
+    puts val
+  end
+end

--- a/scripts/val_from_yaml_test.go
+++ b/scripts/val_from_yaml_test.go
@@ -1,0 +1,123 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("ValFromYaml", func() {
+	const inputContent = `---
+foo:
+  bar:
+   val1: a
+   val2: b
+  array1:
+  - name: item1
+    val: array1_item1_value
+  - name: item2
+    val: array1_item2_value
+  array2:
+  - array2_value1
+  - array2_value2
+  - array2_value3
+`
+
+	var (
+		cmdArg    string
+		session   *gexec.Session
+		inputFile *os.File
+	)
+
+	BeforeEach(func() {
+		cmdArg = ""
+		session = nil
+
+		var err error
+		inputFile, err = ioutil.TempFile("", "val_from_yaml")
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = inputFile.Write([]byte(inputContent))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.Remove(inputFile.Name())
+	})
+
+	JustBeforeEach(func() {
+		command := exec.Command("./val_from_yaml.rb", cmdArg, inputFile.Name())
+
+		var err error
+		session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("argument references a string value", func() {
+		BeforeEach(func() {
+			cmdArg = "foo.bar.val1"
+		})
+
+		It("returns a single string", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(Equal([]byte("a\n")))
+			Expect(session.Err.Contents()).To(BeEmpty())
+		})
+	})
+
+	Context("argument references a hash value", func() {
+		BeforeEach(func() {
+			cmdArg = "foo.bar"
+		})
+
+		It("returns a YAML hash", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(Equal([]byte(`---
+val1: a
+val2: b
+`)))
+			Expect(session.Err.Contents()).To(BeEmpty())
+		})
+	})
+
+	Context("argument references a key that does not exist", func() {
+		BeforeEach(func() {
+			cmdArg = "x.y.z"
+		})
+
+		It("exits non-zero code and error message", func() {
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(session.Out.Contents()).To(BeEmpty())
+			Expect(session.Err.Contents()).To(Equal([]byte("Unable to find key: x.y.z\n")))
+		})
+	})
+
+	Context("argument references a sub-key of a string value", func() {
+		BeforeEach(func() {
+			cmdArg = "foo.var.val1.nothing_to_see_here"
+		})
+
+		It("exits non-zero code and error message", func() {
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(session.Out.Contents()).To(BeEmpty())
+			Expect(session.Err.Contents()).To(Equal([]byte("Unable to find key: foo.var.val1.nothing_to_see_here\n")))
+		})
+	})
+
+	Context("argument references a string value within an array indexed by name keys", func() {
+		BeforeEach(func() {
+			cmdArg = "foo.array1.item1.val"
+		})
+
+		It("returns a single string", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(Equal([]byte("array1_item1_value\n")))
+			Expect(session.Err.Contents()).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
# What
Story: [Deployment Pipeline for Tech Docs to cloudapps.digital](https://www.pivotaltracker.com/story/show/136353551)

Automate the deployment of the paas-tech-docs application. It was made in a generic way so any application can be deployed in a similar fashion.

Depends on PR https://github.com/alphagov/paas-tech-docs/pull/12

# How to review

* Deploy your own dev release Concourse using the README on this branch (you could use your deployer but you may not be able to test the setup pipeline)
* Upload CF API credentials:

```    
DEPLOY_ENV=XXX CF_USER=admin CF_PASS=XXX make dev upload-cf-cli-secrets
```
* Push the setup pipeline (follow the README for details):

```
DEPLOY_ENV=XXX CF_ORG=admin CF_SPACE=admin BRANCH=deploy-tech-docs-136353551 make dev pipelines
```
* The tech-docs app should deploy to your environment automatically

# Before merging
* Merge https://github.com/alphagov/paas-tech-docs/pull/12
* Remove `[TEMP]` commit
* Wait for [the official docker image](https://hub.docker.com/r/governmentpaas/tech-docs/tags/) to build
* Note: the user has already been created in prod and its credentials have been uploaded to CI 

# Who can review
Not @henrytk or me
