### PR TITLE
[#136353551] Deploy tech docs - Fixes

### DIFF
--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -89,8 +89,11 @@ jobs:
               - -e
               - -u
               - -c
-              - -x
               - |
+                if [ -z "${CF_API}" ]; then
+                  echo "\$CF_API is empty, cannot connect to CF API"
+                  exit 1
+                fi
                 echo Logging on to Cloudfoundry...
                 cf login "${CF_API_SECURE:-}" -a "${CF_API}" -u "${CF_USER}" \
                 -p "${CF_PASSWORD}" -o "${CF_ORG}" -s "${CF_SPACE}"

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -22,7 +22,6 @@ aws_account: ${AWS_ACCOUNT}
 releases_bucket_name: ${RELEASES_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases}
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 github_status_context: ${DEPLOY_ENV}/status
-# move
 boshrelease_name: ${boshrelease_name}
 github_repo: ${github_repo}
 github_repo_uri: https://github.com/${github_repo}

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -2,8 +2,7 @@
 set -eu
 
 if [ -z "${CF_API:-}" ]; then
-  echo "You must supply \$CF_API, which is the API target of the Cloud Foundry environment apps will be deployed to"
-  exit 1
+  echo "WARNING: \$CF_API not set, the app deployment pipelines will fail"
 fi
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -29,8 +28,8 @@ concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 pipeline_trigger_file: ${pipeline_name}.trigger
 github_access_token: ${GITHUB_ACCESS_TOKEN}
-cf_api: ${CF_API}
-cf_api_secure: ${CF_API_SECURE}
+cf_api: ${CF_API:-}
+cf_api_secure: ${CF_API_SECURE:-}
 cf_user: ${CF_USER}
 cf_password: ${CF_PASSWORD}
 EOF

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -14,8 +14,6 @@ $("${SCRIPTS_DIR}/environment.sh")
 "${SCRIPTS_DIR}/fly_sync_and_login.sh"
 
 generate_vars_file() {
-  cf_user=$(scripts/val_from_yaml.rb secrets.cf_user <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" -))
-  cf_password=$(scripts/val_from_yaml.rb secrets.cf_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" -))
   cat <<EOF
 ---
 makefile_env_target: ${MAKEFILE_ENV_TARGET}
@@ -33,8 +31,8 @@ pipeline_trigger_file: ${pipeline_name}.trigger
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 cf_api: ${CF_API}
 cf_api_secure: ${CF_API_SECURE}
-cf_user: ${cf_user}
-cf_password: ${cf_password}
+cf_user: ${CF_USER}
+cf_password: ${CF_PASSWORD}
 EOF
 }
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -31,7 +31,11 @@ fi
 
 CF_USER=${CF_USER:-admin}
 if [ -z "${CF_PASSWORD:-}" ]; then
-  CF_PASSWORD=$(scripts/val_from_yaml.rb secrets.cf_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" -))
+  if aws s3 ls "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" > /dev/null; then
+    CF_PASSWORD=$(scripts/val_from_yaml.rb secrets.cf_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" -))
+  else
+    CF_PASSWORD=""
+  fi
 fi
 
 cat <<EOF


### PR DESCRIPTION
# What
Story: [Deployment Pipeline for Tech Docs to cloudapps.digital](https://www.pivotaltracker.com/story/show/136353551)

1. https://github.com/alphagov/paas-release-ci/pull/13 broke in CI because $CF_API_SECURE didn't have a default value.
1. As we forced using $CF_API, $CF_USER and $CF_PASSWORD, we caused a problem for developers caring only about bosh releases. Setting default values solved it too.

# How to review

1. Run `make dev pipelines` without setting $CF_API
1. Simulate CI by removing `$(eval export CF_API_SECURE=--skip-ssl-validation)` from the Makefile and running `make dev pipelines`

# Who can review
Not me
