### PR TITLE
[#136353551] Rename tech-docs app to paas-tech-docs

### DIFF
--- a/app-deploy.d/paas-tech-docs
+++ b/app-deploy.d/paas-tech-docs
@@ -1,4 +1,4 @@
-APP_NAME="tech-docs"
+APP_NAME="paas-tech-docs"
 APP_REPOSITORY="https://github.com/alphagov/paas-tech-docs.git"
 APP_BRANCH="master"
 APP_DOCKER_IMAGE="governmentpaas/tech-docs"


### PR DESCRIPTION
# What

Story: [Deployment Pipeline for Tech Docs to cloudapps.digital](https://www.pivotaltracker.com/story/show/136353551)

To match the official name of the app deployed in production.

# How to review
Code review

# After merging
* Delete tech-docs CI pipeline
* Delete tech-docs app in prod

# Who can review
Not me
