### PR TITLE
[#140832481] Add product page to app deployment

### DIFF
--- a/app-deploy.d/paas-product-page
+++ b/app-deploy.d/paas-product-page
@@ -1,0 +1,6 @@
+APP_NAME="paas-product-page"
+APP_REPOSITORY="https://github.com/alphagov/paas-product-page.git"
+APP_BRANCH="master"
+APP_DOCKER_IMAGE="governmentpaas/paas-product-page"
+APP_CF_ORG="govuk-paas"
+APP_CF_SPACE="docs"


### PR DESCRIPTION
## What

As the tech-docs have proven to work with its approach, we'd like to use it for our product-page as well.

We're simply adding another app configuration, that will be considered in the loop.

## How to review


* Deploy your own dev release Concourse using the README on this branch (you could use your deployer but you may not be able to test the setup pipeline)
* Upload CF API credentials:

```    
DEPLOY_ENV=XXX CF_USER=admin CF_PASS=XXX make dev upload-cf-cli-secrets
```
* Push the setup pipeline (follow the README for details):

```
DEPLOY_ENV=XXX BRANCH= automated_deployment_140832481 make dev pipelines
```
* The `product-page` app should deploy to your environment automatically

## Who can review

Not @paroxp