### PR TITLE
[#141231851] Fix path to CDN broker Bosh release repository

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -54,4 +54,4 @@ setup_release_pipeline datadog-agent alphagov/paas-datadog-agent-boshrelease gds
 setup_release_pipeline syslog alphagov/paas-syslog-release gds_master
 setup_release_pipeline ipsec alphagov/paas-ipsec-release gds_master
 setup_release_pipeline grafana alphagov/paas-grafana-boshrelease gds_master
-setup_release_pipeline cdn-broker alphagov/paas-cdn-broker master
+setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master


### PR DESCRIPTION
## What

This has changed now that we have a separate repository for the Bosh
release, which submodules in the CDN broker.

This was done because it allows us to contribute changes upstream and
it stops us breaking Go import paths. We still need to fix the three-
pull-request dance we do when developing Bosh releases, but that can
be addressed as a different piece of work (preferably on the RDS broker,
since it is more stable and is not a fork).

## How to review

Check the path matches the path to the repository in GitHub

## Who

Anyone but @combor or me.