### PR TITLE
[#145211537] Pin all governmentpaas containers to a version

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -19,11 +19,13 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
+      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
 
   - name: semver-iam
     type: docker-image
     source:
       repository: governmentpaas/semver-resource
+      tag: dc33fee5c9061263e83159a893340f46728d93b5
 
 resources:
   - name: bosh-release-pr
@@ -74,6 +76,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: bosh-release-pr
           outputs:

--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -140,7 +140,11 @@ jobs:
       - task: build
         config:
           platform: linux
-          image: docker:///governmentpaas/bosh-cli
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: bosh-release-repo
             - name: bosh-release-version

--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -74,6 +74,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: files-to-push
           params:

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -4,11 +4,13 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
+      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
 
   - name: semver-iam
     type: docker-image
     source:
       repository: governmentpaas/semver-resource
+      tag: dc33fee5c9061263e83159a893340f46728d93b5
 
 resources:
   - name: pipeline-trigger
@@ -52,6 +54,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-release-ci
             - name: release-ci-tfstate

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -4,11 +4,13 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
+      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
 
   - name: semver-iam
     type: docker-image
     source:
       repository: governmentpaas/semver-resource
+      tag: dc33fee5c9061263e83159a893340f46728d93b5
 
 resources:
   - name: pipeline-trigger
@@ -43,6 +45,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-release-ci
           params:
@@ -88,6 +91,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/curl-ssl
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-release-ci
           run:
@@ -114,6 +118,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-release-ci
             - name: release-ci-tfstate
@@ -152,6 +157,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-release-ci
           params:


### PR DESCRIPTION
## What

So that we can control how containers are updated between environments and
prevent forwards/backwards incompatibilities with code in the pipeline.

This will also prevent Concourse from re-downloading all of the containers
each time we merge a change to alphagov/paas-docker-cloudfoundry-tools
because Docker Hub rebuilds everything.

Using the functionality added in:

- alphagov/paas-docker-cloudfoundry-tools#93

## How to review

1. Eyeball the diff and make sure that it looks sensible
1. Run at least one pipeline and confirm that it still works

## Who can review

Not @dcarley