### PR TITLE
[#140847887] Change pipeline pausing in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ dev: globals check-env-vars ## Work on the dev account
 	$(eval export MAKEFILE_ENV_TARGET=dev)
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
+	$(eval export UNPAUSE_PIPELINES=false)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export CF_API_SECURE=--skip-ssl-validation)
 	@true
@@ -21,7 +22,6 @@ ci: globals ## Work on the ci account
 	$(eval export MAKEFILE_ENV_TARGET=ci)
 	$(eval export DEPLOY_ENV=build)
 	$(eval export AWS_ACCOUNT=ci)
-	$(eval export ENABLE_AUTO_TRIGGER=true)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export CONCOURSE_ATC_PASSWORD_PASS_FILE=ci_deployments/build/concourse_password)
 	$(eval export CF_API=https://api.cloud.service.gov.uk)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A pipeline should be created for each Bosh release this repository is currently 
 
 * Run `DEPLOY_ENV=... make dev upload-cf-cli-secrets`. You can override the credentials used by setting `CF_USER` and `CF_PASSWORD`.
 * Run `CF_API=... DEPLOY_ENV=... make dev pipelines`, where `CF_API` is the URL of your dev Cloud Foundry API.
-* The `setup` pipeline doesn't auto-trigger in Dev. Visit your running Concourse instance in a browser and trigger it manually,  or set the environment variable `ENABLE_AUTO_TRIGGER` to `true` at the previous step.
+* The individual build and test pipelines are paused in Dev. You can manaully unpause the ones that you need to work on, but be aware that they will submit their results to GitHub pull requests.
 
 ## Overriding variables
 

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -37,7 +37,7 @@ jobs:
   - name: self-update
     plan:
       - get: paas-release-ci
-        trigger: {{auto_trigger}}
+        trigger: true
       - task: self-update-pipeline
         config:
           platform: linux

--- a/scripts/deploy-pipeline.sh
+++ b/scripts/deploy-pipeline.sh
@@ -38,9 +38,11 @@ yes y | \
    --pipeline "${pipeline}" \
    --load-vars-from "${varsfile}"
 
-$FLY_CMD -t "${FLY_TARGET}" \
-  unpause-pipeline \
-  --pipeline "${pipeline}"
+if [ "${UNPAUSE_PIPELINES:-true}" != "false" ]; then
+  $FLY_CMD -t "${FLY_TARGET}" \
+    unpause-pipeline \
+    --pipeline "${pipeline}"
+fi
 
 $FLY_CMD -t "${FLY_TARGET}" \
   expose-pipeline \

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -36,17 +36,10 @@ cf_password: ${CF_PASSWORD}
 EOF
 }
 
-generate_manifest_file() {
-  # This exists because concourse does not support boolean value interpolation by design
-  enable_auto_trigger=$([ "${ENABLE_AUTO_TRIGGER:-}" ] && echo "true" || echo "false")
-  sed -e "s/{{auto_trigger}}/${enable_auto_trigger}/" \
-    < "${PIPELINES_DIR}/${pipeline_name}.yml"
-}
-
 upload_pipeline() {
-  bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
+  UNPAUSE_PIPELINES=true bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
         "${pipeline_name}" \
-        <(generate_manifest_file) \
+        "${PIPELINES_DIR}/${pipeline_name}.yml" \
         <(generate_vars_file)
 }
 


### PR DESCRIPTION
## What

It has long confused me that you need to manually run the `setup` pipeline
when you create a Build Concourse in a dev environment, but then *all* of
the other pipelines run and start submitting build results back to GitHub.

I think it makes more sense to automatically trigger the `setup` pipeline
but pause all of the release pipelines. Then you can unpause the release
that you intend to work on.

I've set the `setup` and `destroy` pipelines to explicitly not be paused.

## How to review

I have tested this and I think code review only would be acceptable.

If you'd prefer to test it yourself, the instructions are:

1. Have a Concourse to deploy to:
    - Ideally create a "build" Concourse using [paas-bootstrap](https://github.com/alphagov/paas-bootstrap) with a different `DEPLOY_ENV` from your "deployer".
    - You could use your existing "deployer" and set `CONCOURSE_URL` if you clean up the pipelines afterwards.
1. Deploy pipelines from this branch:

       git fetch
       git checkout feature/140847887-change_pipeline_pausing_in_dev
       BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
1. Confirm that the `setup` pipeline is unpaused has automatically triggered.
1. Confirm that the other pipelines are paused.

## Who can review

Anyone.