### PR TITLE
[#140847887] Rename release pipelines to have -release suffix

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -32,14 +32,23 @@ EOF
 }
 
 setup_release_pipeline() {
+  pipeline_name="${1}-release"
   boshrelease_name="$1"
   github_repo="$2"
   final_release_branch="$3"
 
   generate_vars_file > /dev/null # Check for missing vars
 
+  # FIXME: Remove when deployed.
+  if $FLY_CMD -t "${FLY_TARGET}" pipelines | grep -qE "^${boshrelease_name}\s"; then
+    $FLY_CMD -t "${FLY_TARGET}" \
+      rename-pipeline \
+      -o "${boshrelease_name}" \
+      -n "${pipeline_name}"
+  fi
+
   bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
-    "${boshrelease_name}" \
+    "${pipeline_name}" \
     "${PIPELINES_DIR}/build-release.yml" \
     <(generate_vars_file)
 }


### PR DESCRIPTION
## What

We want to introduce new pipelines to test pull requests on the code repos,
e.g. paas-rds-broker rather than paas-rds-broker-boshrelease. The existing
naming makes this confusing.

We need to use a command with a FIXME comment to rename the pipelines
in-place so that the build history is kept. This should be a noop on the 2nd
run. Then the `rename-pipeline` command can be removed.

## How to review

1. Deploy a "build" Concourse using [paas-bootstrap](https://github.com/alphagov/paas-bootstrap) making sure that you use a different `DEPLOY_ENV` from your "deployer" Concourse.
1. Upload pipelines from the `master` branch:

       git checkout master
       git pull
       make dev pipelines
1. Run the `setup` pipeline and confirm that it creates all of the BOSH release pipelines.
1. Upload pipelines from this branch:

       git fetch
       git checkout feature/140847887-rename_release_pipelines
       BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
1. Run the `setup` pipeline and confirm that it renames (not recreates) all of the BOSH release pipelines to have a "-release" suffix.
1. Run the `setup` pipeline again and confirm that it doesn't attempt to rename the pipelines anymore.

## Who can review

Anyone