### PR TITLE
[#146152015] Handle concourse password changes in self-update-pipelines

### DIFF
--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -53,7 +53,6 @@ jobs:
             DEPLOY_ENV: {{deploy_env}}
             BRANCH: {{branch_name}}
             MAKEFILE_ENV_TARGET: {{makefile_env_target}}
-            CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
             CONCOURSE_URL: {{concourse_url}}
             GITHUB_ACCESS_TOKEN: {{github_access_token}}
             STATE_BUCKET_NAME: {{state_bucket_name}}


### PR DESCRIPTION
## What

The self-update-pipelines currently will error if the concourse password
is changed. This is because the password is passed around in a loop, and
therefore the new one isn't pulled from the S3 bucket. Breaking this
loop means that the password will be pulled from S3 each time, and
therefore will be updated.

## How to review

* Deploy the pipelines from this branch to a build concourse.
* Rotate the credentials for the build concourse
* Verify that the setup pipeline runs correctly with the new credentials.

Note: Due to the fact that the creds for CI have already been rotated, the pipelines will still need to be manually pushed there to fix it. This should prevent this breaking again in future though.

## Who can review

Not me.