### PR TITLE
[#146152015] Deploys apps in serial

### DIFF
--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -35,6 +35,7 @@ jobs:
                 cd {{app_name}} && ./release/test
 
   - name: deploy
+    serial: true
     plan:
       - get: {{app_name}}
         passed: ['test']


### PR DESCRIPTION
## What

Because I don't know what Cloud Foundry will do if two commits land on the
master branch in quick succession and result in two parallel deployments
happening at the same time.

I noticed this because app deployments are currently broken by credential
rotation in Pivotal story #146152015 and this has caused several builds to
get stuck in the pending state.

It is still safe to run the test task in parallel.

## How to review

I checked that this is syntactically correct and applies to a build Concourse. I haven't tested that it does that I've told it when multiple builds are run, because I don't have a CF environment up at the moment. Given that small change and that it's a Concourse feature I think code review only is sufficient.

## Who can review

Anyone