### PR TITLE
[#140847887] Run integration tests for paas-rds-broker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ boshrelease-pipelines: ## Upload boshrelease pipelines to concourse
 app-deployment-pipelines: ## Upload app deployment pipelines to concourse
 	@scripts/build-app-deployment-pipelines.sh
 
+.PHONY: integration-test-pipelines
+integration-test-pipelines: ## Upload integration test pipelines to concourse
+	@scripts/integration-test-pipelines.sh
+
 showenv: ## Display environment information
 	@scripts/environment.sh
 

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -1,0 +1,42 @@
+---
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: jtarchie/pr
+
+resources:
+  - name: pr
+    type: pull-request
+    source:
+      repo: {{github_repo}}
+      access_token: {{github_access_token}}
+      every: true
+      disable_forks: true
+
+jobs:
+  - name: integration-test
+    serial: true
+    plan:
+      - get: pr
+        version: every
+        trigger: true
+      - put: pr
+        params:
+          path: pr
+          context: {{github_status_context}}
+          status: pending
+      - task: run-tests
+        file: pr/ci/integration.yml
+    on_success:
+      put: pr
+      params:
+        path: pr
+        context: {{github_status_context}}
+        status: success
+    on_failure:
+      put: pr
+      params:
+        path: pr
+        context: {{github_status_context}}
+        status: failure

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -180,4 +180,5 @@ jobs:
               - -c
               - |
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" boshrelease-pipelines
+                make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" integration-test-pipelines
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" app-deployment-pipelines

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eu
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")" && pwd)
+PIPELINES_DIR="${SCRIPTS_DIR}/../pipelines"
+
+# shellcheck disable=SC2091
+$("${SCRIPTS_DIR}/environment.sh")
+"${SCRIPTS_DIR}/fly_sync_and_login.sh"
+
+generate_vars_file() {
+   cat <<EOF
+---
+github_access_token: ${GITHUB_ACCESS_TOKEN}
+github_status_context: ${DEPLOY_ENV}/status
+github_repo: ${github_repo}
+EOF
+}
+
+setup_test_pipeline() {
+  pipeline_name="$1"
+  github_repo="$2"
+
+  generate_vars_file > /dev/null # Check for missing vars
+
+  bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
+    "${pipeline_name}" \
+    "${PIPELINES_DIR}/integration-test.yml" \
+    <(generate_vars_file)
+}
+
+setup_test_pipeline rds-broker alphagov/paas-rds-broker

--- a/scripts/pipecleaner.py
+++ b/scripts/pipecleaner.py
@@ -40,8 +40,13 @@ class Pipecleaner(object):
         data = self.load_pipeline(filename)
         return self.check_pipeline(data)
 
-    def load_pipeline(self, filename):
-        raw = open(filename).read()
+    def load_pipeline(self, filename, ignore_missing=False):
+        try:
+          raw = open(filename).read()
+        except IOError:
+          if not ignore_missing: raise
+          raw = "{}"
+
         raw = re.sub('\{\{.*?\}\}', 'DUMMY', raw)
         return yaml.load(raw)
 
@@ -149,7 +154,7 @@ class Pipecleaner(object):
 
                 if 'task' in item:
                     if 'file' in item:
-                        item['config'] = self.load_pipeline(item['file'])
+                        item['config'] = self.load_pipeline(item['file'], ignore_missing=True)
 
                     if 'inputs' in item['config']:
                         for i in item['config']['inputs']:


### PR DESCRIPTION
## What

Introduces a pattern for running integration tests for pull requests on code
repos (which are later consumed by BOSH release repos).

Each one should have a `ci/integration.yml` file defining the task to run
the tests and assumes a single input directory called `pr`. Build status
will be submitted back to GitHub.

At the moment we only have paas-rds-broker.

## How to review

1. Review the code and commits.
1. Create a Build Concourse using [paas-bootstrap](https://github.com/alphagov/paas-bootstrap) (use a different `DEPLOY_ENV` from your Deployer Concourse!).
1. Checkout this branch and deploy pipelines:

       git fetch && git checkout feature/140847887-integration_test_pipelines
       BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
1. Wait for the `setup` pipeline to auto-trigger and create the other pipelines.
1. Unpause the new `paas-rds-broker` pipeline.
1. Wait for the `paas-rds-broker` pipeline to automatically build alphagov/paas-rds-broker#42
1. Confirm that the build finished successfully.

Once you're happy, the PRs need to be merged in the following order:

1. [government-paas/aws-account-wide-terraform#93](https://github.digital.cabinet-office.gov.uk/government-paas/aws-account-wide-terraform/pull/93)
1. alphagov/paas-rds-broker#42
1. This PR

## Who can review

Not @dcarley or @bleach