### PR TITLE
[#147445891] Compose integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     unzip -o terraform_${TF_VERSION}_linux_amd64.zip -d ~/bin
     rm terraform_${TF_VERSION}_linux_amd64.zip
   - pip install --user yamllint
-  - eval "$(gimme 1.6)"
+  - eval "$(gimme 1.8)"
   - export GOPATH=$HOME/gopath
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/onsi/ginkgo/ginkgo

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ upload-cf-cli-secrets: check-env-vars ## Decrypt and upload CF CLI credentials t
 	$(if $(wildcard ${CF_CLI_PASSWORD_STORE_DIR}),,$(error Password store ${CF_CLI_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-cf-cli-secrets.sh
 
+.PHONY: upload-compose-secrets
+upload-compose-secrets: check-env-vars ## Decrypt and upload Compose credentials to S3
+	$(eval export COMPOSE_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/ci))
+	$(if ${COMPOSE_PASSWORD_STORE_DIR},,$(error Must pass COMPOSE_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${COMPOSE_PASSWORD_STORE_DIR}),,$(error Password store ${COMPOSE_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-compose-secrets.sh
+
 .PHONY: pipelines
 pipelines: ## Upload setup pipelines to concourse
 	@scripts/deploy-setup-pipelines.sh
@@ -53,7 +61,6 @@ integration-test-pipelines: ## Upload integration test pipelines to concourse
 
 showenv: ## Display environment information
 	@scripts/environment.sh
-
 
 ## Testing tasks
 

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -5,6 +5,12 @@ resource_types:
     source:
       repository: jtarchie/pr
 
+  - name: s3-iam
+    type: docker-image
+    source:
+      repository: governmentpaas/s3-resource
+      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+
 resources:
   - name: pr
     type: pull-request
@@ -14,29 +20,89 @@ resources:
       every: true
       disable_forks: true
 
+  - name: release-repository
+    type: git
+    source:
+      branch: {{tag_branch}}
+      ignore_paths:
+        - {{version_file}}
+      private_key: {{tagging_key}}
+      uri: {{github_repo_uri}}
+
+  - name: resource-version
+    type: semver
+    source:
+      branch: {{tag_branch}}
+      driver: git
+      file: {{version_file}}
+      git_user: "GovUK-PaaS-CI-User <the-multi-cloud-paas-team+ci-github-user@digital.cabinet-office.gov.uk>"
+      initial_version: 0.0.1
+      private_key: {{tagging_key}}
+      uri: {{github_repo_uri}}
+
+  - name: secrets
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: {{secrets_file}}
+
 jobs:
   - name: integration-test
     serial: true
     plan:
-      - get: pr
+      - get: secrets
+      - get: repo
+        resource: pr
         version: every
         trigger: true
-      - put: pr
+      - put: repo
+        resource: pr
         params:
-          path: pr
+          path: repo
           context: {{github_status_context}}
           status: pending
       - task: run-tests
-        file: pr/ci/integration.yml
+        params:
+          STATE_BUCKET: {{state_bucket}}
+          AWS_REGION: {{aws_region}}
+          SECRETS_FILE: {{secrets_file}}
+        file: repo/ci/integration.yml
     on_success:
-      put: pr
+      put: repo
+      resource: pr
       params:
-        path: pr
+        path: repo
         context: {{github_status_context}}
         status: success
     on_failure:
-      put: pr
+      put: repo
+      resource: pr
       params:
-        path: pr
+        path: repo
         context: {{github_status_context}}
         status: failure
+
+  - name: tag-releases
+    serial: true
+    plan:
+    - get: repo
+      resource: release-repository
+      trigger: true
+    - get: secrets
+    - get: resource-version
+      params:
+        bump: minor
+    - task: run-tests
+      file: repo/ci/integration.yml
+      on_success:
+        put: resource-version
+        params:
+          file: resource-version/number
+    on_success:
+      put: release-repository
+      params:
+        only_tag: true
+        repository: repo
+        tag: resource-version/number
+        tag_prefix: "v"

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -33,6 +33,20 @@ resources:
       region_name: {{aws_region}}
       versioned_file: release-ci.tfstate
 
+  - name: ssh-private-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket_name}}
+      versioned_file: ci_build_tag_key
+      region_name: {{aws_region}}
+
+  - name: ssh-public-key
+    type: s3-iam
+    source:
+      bucket: {{state_bucket_name}}
+      versioned_file: ci_build_tag_key.pub
+      region_name: {{aws_region}}
+
 jobs:
   - name: self-update
     plan:
@@ -100,6 +114,9 @@ jobs:
               - -c
               - |
                 paas-release-ci/scripts/s3init.sh {{state_bucket_name}} release-ci.tfstate paas-release-ci/pipelines/init_files/terraform.tfstate.tpl
+                paas-release-ci/scripts/s3init.sh {{state_bucket_name}} ci_build_tag_key paas-release-ci/pipelines/init_files/zero_bytes
+                paas-release-ci/scripts/s3init.sh {{state_bucket_name}} ci_build_tag_key.pub paas-release-ci/pipelines/init_files/zero_bytes
+                paas-release-ci/scripts/s3init.sh {{state_bucket_name}} no-secrets-needed paas-release-ci/pipelines/init_files/zero_bytes
 
   - name: terraform
     plan:
@@ -141,11 +158,65 @@ jobs:
           put: release-ci-tfstate
           params:
             file: updated-release-ci-tfstate/release-ci.tfstate
+
+  - name: generate-ssh-keys
+    serial: true
+    plan:
+      - aggregate:
+         - get: ssh-private-key
+         - get: ssh-public-key
+         - get: pipeline-trigger
+           passed: ['terraform']
+           trigger: true
+      - task: generate-deployments-ssh-keypair
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/git-ssh
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: ssh-private-key
+            - name: ssh-public-key
+          outputs:
+            - name: generated-ssh-private-key
+            - name: generated-ssh-public-key
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if [ -s ssh-private-key/ci_build_tag_key ] ; then
+                  echo "Deployments private key non-zero size, skipping generation..."
+                  echo "Key uploads will fail and this is OK as no new keys have been generated."
+                  echo "Existing ssh key is ..."
+                  cat ssh-public-key/ci_build_tag_key.pub
+                  exit 0
+                fi
+
+                echo "Generating new ssh key pair for deployments..."
+                ssh-keygen -t rsa -b 4096 -f ci_build_tag_key -N ''
+                echo "New ssh key is ..."
+                cat ci_build_tag_key.pub
+                cp ci_build_tag_key generated-ssh-private-key
+                cp ci_build_tag_key.pub generated-ssh-public-key
+        on_success:
+          try:
+            aggregate:
+              - put: ssh-private-key
+                params:
+                  file: generated-ssh-private-key/ci_build_tag_key
+              - put: ssh-public-key
+                params:
+                  file: generated-ssh-public-key/ci_build_tag_key.pub
+
   - name: dynamic-pipelines
     plan:
       - aggregate:
           - get: pipeline-trigger
-            passed: ['terraform']
+            passed: ['generate-ssh-keys']
             trigger: true
           - get: paas-release-ci
             passed: ['terraform']
@@ -180,5 +251,5 @@ jobs:
               - -c
               - |
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" boshrelease-pipelines
-                make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" integration-test-pipelines
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" app-deployment-pipelines
+                make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" integration-test-pipelines

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -9,17 +9,34 @@ $("${SCRIPTS_DIR}/environment.sh")
 "${SCRIPTS_DIR}/fly_sync_and_login.sh"
 
 generate_vars_file() {
-   cat <<EOF
+SSH_KEY=$(aws s3 cp s3://"${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}"/ci_build_tag_key -)
+  cat << EOF
 ---
+pipeline_name: ${pipeline_name}
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 github_status_context: ${DEPLOY_ENV}/status
-github_repo: ${github_repo}
+state_bucket: ${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}
+aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
+branch_name: ${BRANCH:-master}
+organisation: ${organisation}
+repository: ${repository}
+github_repo: ${organisation}/${repository}
+github_repo_uri: git@github.com:${organisation}/${repository}.git
+tag_branch: ${tag_branch}
+version_file: ${version_file}
+secrets_file: ${secrets_file}
 EOF
+echo -e "tagging_key: |\n  ${SSH_KEY//$'\n'/$'\n'  }"
 }
 
 setup_test_pipeline() {
   pipeline_name="$1"
-  github_repo="$2"
+  version_file="version"
+  organisation="$2"
+  repository="$3"
+  tag_branch="$4"
+  secrets_file="${5:-no-secrets-needed}"
+
 
   generate_vars_file > /dev/null # Check for missing vars
 
@@ -27,6 +44,9 @@ setup_test_pipeline() {
     "${pipeline_name}" \
     "${PIPELINES_DIR}/integration-test.yml" \
     <(generate_vars_file)
+
 }
 
-setup_test_pipeline rds-broker alphagov/paas-rds-broker
+setup_test_pipeline rds-broker alphagov paas-rds-broker master
+setup_test_pipeline compose-broker alphagov paas-compose-broker master compose-broker-secrets.yml
+

--- a/scripts/upload-compose-secrets.sh
+++ b/scripts/upload-compose-secrets.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${COMPOSE_PASSWORD_STORE_DIR}
+
+COMPOSE_ACCESS_TOKEN=$(pass "compose/integration_tests/access_token")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+compose_access_token: ${COMPOSE_ACCESS_TOKEN}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/compose-broker-secrets.yml"


### PR DESCRIPTION
## What 

This PR adds an integration configuration and version file for running integration tests on PRs via Concourse in the CI environment. In addition pipecleaner has had to have some additional work undertaken in order to handle external task files and resources loaded in the main pipeline and then consumed in the external task file.

## How to review 

1. https://github.com/alphagov/paas-credentials/pull/82 needs to be merged first
1. Create a dev build concourse via paas-bootstrap
1. Upload compose secrets with `make dev upload-compose-secrets`
1. Push the pipelines from this branch `make dev pipelines` for setup, `make dev integration-test-pipelines` for the integration pipelines, these include the new test and tag pipeline.
1. Run the Setup pipeline, this will generate a SSH keypair
1. Login to Github with the CI user (in creds store) and add the generated pub key to the user
1. Run the Compose broker and RDS broker pipelines
1. Delete pub key from CI Github user


## Merging

1. `make ci upload-compose-secrets` must be performed by someone with access to the high creds store.
1. Remove the tmp commit that points at the compose_integration_branch
1. Following this, the merge process is as usual.

## Who can review 

Not @combor or @LeePorte or @paroxp or @dcarley 