### PR TITLE
[#150512756] Upgrade concourse

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -19,13 +19,13 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
-      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+      tag: 594eaa9f4d93b2ed32a7e5e1cdea5b380e2f6682
 
   - name: semver-iam
     type: docker-image
     source:
       repository: governmentpaas/semver-resource
-      tag: dc33fee5c9061263e83159a893340f46728d93b5
+      tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
 resources:
   - name: bosh-release-pr

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -4,13 +4,13 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
-      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+      tag: 594eaa9f4d93b2ed32a7e5e1cdea5b380e2f6682
 
   - name: semver-iam
     type: docker-image
     source:
       repository: governmentpaas/semver-resource
-      tag: dc33fee5c9061263e83159a893340f46728d93b5
+      tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
 resources:
   - name: pipeline-trigger

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -9,7 +9,7 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
-      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+      tag: 594eaa9f4d93b2ed32a7e5e1cdea5b380e2f6682
 
 resources:
   - name: pr

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -4,13 +4,13 @@ resource_types:
     type: docker-image
     source:
       repository: governmentpaas/s3-resource
-      tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+      tag: 594eaa9f4d93b2ed32a7e5e1cdea5b380e2f6682
 
   - name: semver-iam
     type: docker-image
     source:
       repository: governmentpaas/semver-resource
-      tag: dc33fee5c9061263e83159a893340f46728d93b5
+      tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
 resources:
   - name: pipeline-trigger

--- a/scripts/deploy-pipeline.sh
+++ b/scripts/deploy-pipeline.sh
@@ -31,12 +31,12 @@ echo "Concourse API target: ${FLY_TARGET}"
 echo "Pipeline: ${pipeline}"
 echo "Config file: ${config}"
 
-yes y | \
-   $FLY_CMD -t "${FLY_TARGET}" \
+$FLY_CMD -t "${FLY_TARGET}" \
    set-pipeline \
    --config "${config}" \
    --pipeline "${pipeline}" \
-   --load-vars-from "${varsfile}"
+   --load-vars-from "${varsfile}" \
+   --non-interactive
 
 if [ "${UNPAUSE_PIPELINES:-true}" != "false" ]; then
   $FLY_CMD -t "${FLY_TARGET}" \

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -44,7 +44,7 @@ upload_pipeline() {
 }
 
 remove_pipeline() {
-  yes y | ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" || true
+  ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" --non-interactive || true
 }
 
 pipeline_name=setup

--- a/scripts/fly_sync_and_login.sh
+++ b/scripts/fly_sync_and_login.sh
@@ -17,8 +17,7 @@ curl "$FLY_CMD_URL" -# -L -f ${timestamp_flag:+-z "$FLY_CMD"} -o "$FLY_CMD" -u "
 chmod +x "$FLY_CMD"
 
 echo "Doing fly login"
-echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
-  $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}"
+$FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_ATC_USER}" -p "${CONCOURSE_ATC_PASSWORD}"
 
 echo "Doing fly sync"
-  $FLY_CMD -t "${FLY_TARGET}" sync
+$FLY_CMD -t "${FLY_TARGET}" sync


### PR DESCRIPTION
## What

We'd like to catchup with the releases of deployer and bootstrap Concourse, and estimated upgrading to the latest one will satisfy us best.

- We're far behind
- We're not upgrading as often as we'd wish to
- It contains a lot of fixes reported over time, including a change to container volumes that we think should prevent the need to "shake" Concourse

## How to review

These instructions rely on self-updating pipelines. Please ensure that you are not disabling them in your dev environment.

:bee: :bee: :bee:
1. There is a `WIP` commit which must not be merged as is. It will need to be updated after the alphagov/paas-semver-resource#7 and alphagov/paas-s3-resource#6 are merged.

:bee: :bee: :bee:

You may wish to use a different `DEPLOY_ENV` for this so that you don't affect your existing dev environment.

- Deploy bootstrap from `upgrade-concourse-150512756` branch of `paas-bootstrap`
- Log into the Bootstrap Concourse and confirm that the version in the bottom right corner says `3.4.1`
- Run the `create-bosh-concourse` pipeline
- Log into the new CI Concourse and confirm that the version in the bottom right corner says `3.4.1`

## Who can review

Neither of @LeePorte, @dcarley nor @paroxp