### PR TITLE
Add a pull-request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What
+
+Describe what you have changed and why.
+
+## How to review
+
+Describe the steps required to test the changes.
+
+## Who can review
+
+Describe who can review the changes. Or more importantly, list the people
+that can't review, because they worked on it.


### PR DESCRIPTION
Github now supports templates for PRs[1]. This adds a template that
follows the recommendations in the team manual[2]

[1]https://github.com/blog/2111-issue-and-pull-request-templates
[2]https://government-paas-team-manual.readthedocs.org/en/latest/team/working_practices/#pull-requests