### PR TITLE
[#151010442] Copy dotfiles when pushing apps

### DIFF
--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -75,7 +75,7 @@ jobs:
               - |
                 copy_files() {
                   echo "Copying files to destination..."
-                  cp -pr ((app_name))/* files-to-push/
+                  cp -pr ((app_name))/. files-to-push
                   ls -l files-to-push
                 }
 


### PR DESCRIPTION
## What

The existing code did not copy dotfiles when deploying apps. This caused the new product page [1] to fail to deploy because `.ruby-version` is read by `Gemfile` during deploy but was not present.

Experimentally this command does copy dotfiles, copies into the root of `files-to-push`, and works regardless whether `files-to-push`.

[1] https://github.com/alphagov/paas-product-page/pull/26

## How to review

I'm not certain that the CI server's `cp` and shell will behave the same way, so it might be best to try this out.

## Who can review

Not @46bit