### PR TITLE
[#151322324] Add route-registrar pipeline

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -56,3 +56,4 @@ setup_release_pipeline syslog alphagov/paas-syslog-release gds_master
 setup_release_pipeline ipsec alphagov/paas-ipsec-release gds_master
 setup_release_pipeline grafana alphagov/paas-grafana-boshrelease gds_master
 setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
+setup_release_pipeline route-registrar alphagov/paas-route-registrar gds_master


### PR DESCRIPTION
## What

As part of #151322324, we've decided that we would like to fork the
upstream route-registrar repo in order to extend its functionality to
support the TLS port. This work has already been done but not merged in.
See: cloudfoundry/route-registrar#18 opened by GOV.AU.

We intend to go back into using the upstream release as soon as there is
a similar fix merged in, making this commit obsolete.

## How to review

- Sanity check should be sufficient.

## Who can review

Neither @bandesz nor myself.
