### PR TITLE
[#151322324] Change the release repository

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -56,4 +56,4 @@ setup_release_pipeline syslog alphagov/paas-syslog-release gds_master
 setup_release_pipeline ipsec alphagov/paas-ipsec-release gds_master
 setup_release_pipeline grafana alphagov/paas-grafana-boshrelease gds_master
 setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
-setup_release_pipeline route-registrar alphagov/paas-route-registrar gds_master
+setup_release_pipeline routing alphagov/paas-routing-release gds_master


### PR DESCRIPTION
## What

Previous commit is pointing to the wrong repository, which is an actual
route-registrar whilst we're after an actual boshrelease repo...

We're supplementing that with this change.

My bad. I'm sorry 😞 

## How to review

- Sanity check
- Check if the repo actually exists and is the boshrelease repo...
