### PR TITLE
[#152670228] Add Elasticache integration tests

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -50,3 +50,4 @@ setup_test_pipeline() {
 setup_test_pipeline rds-broker alphagov paas-rds-broker master
 setup_test_pipeline compose-broker alphagov paas-compose-broker master compose-broker-secrets.yml
 setup_test_pipeline usage-events-collector alphagov paas-usage-events-collector master
+setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker master


### PR DESCRIPTION
## What

Add the Elasticache broker integration tests.

## How to review

This depends on https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/102, which should be merged and built first.

Make sure the integration tests run successfully.

### Before merging

Remove the temporary commit which pins the dev branch of the Elasticache broker.

## Who can review

Anyone but me or @camelpunch 
