### PR TITLE
[#138512111] Deploy rubbernecker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ upload-deskpro-secrets: check-env-vars ## Decrypt and upload DeskPro credentials
 	$(if $(wildcard ${DESKPRO_PASSWORD_STORE_DIR}),,$(error Password store ${DESKPRO_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-deskpro-secrets.sh
 
+.PHONY: upload-rubbernecker-secrets
+upload-rubbernecker-secrets: check-env-vars ## Decrypt and upload DeskPro credentials to S3
+	$(eval export RUBBERNECKER_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${RUBBERNECKER_PASSWORD_STORE_DIR},,$(error Must pass RUBBERNECKER_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${RUBBERNECKER_PASSWORD_STORE_DIR}),,$(error Password store ${RUBBERNECKER_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-rubbernecker-secrets.sh
+
 .PHONY: pipelines
 pipelines: ## Upload setup pipelines to concourse
 	@scripts/deploy-setup-pipelines.sh

--- a/app-deploy.d/rubbernecker
+++ b/app-deploy.d/rubbernecker
@@ -1,0 +1,9 @@
+APP_NAME="rubbernecker"
+APP_REPOSITORY="https://github.com/alphagov/paas-rubbernecker.git"
+APP_BRANCH="master"
+# Rubbernecker doesn't currently have a test script, so use alpine as it's
+# small and has enough to allow the pipeline script to work.
+APP_DOCKER_IMAGE="alpine"
+APP_CF_ORG="govuk-paas"
+APP_CF_SPACE="tools"
+SECRETS_FILE="rubbernecker-secrets.yml"

--- a/scripts/upload-rubbernecker-secrets.sh
+++ b/scripts/upload-rubbernecker-secrets.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${RUBBERNECKER_PASSWORD_STORE_DIR}
+
+PIVOTAL_API_KEY=$(pass "pivotal/tracker_token")
+PAGERDUTY_API_TOKEN=$(pass "pagerduty/rubbernecker_api_token")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+pivotal_project_id: 1275640
+pivotal_api_key: ${PIVOTAL_API_KEY}
+pagerduty_api_token: ${PAGERDUTY_API_TOKEN}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/rubbernecker-secrets.yml"


### PR DESCRIPTION
## What

Add a pipeline to deploy rubbernecker.

## How to review

It may be enough to code-review this - I've tested it in a dev build concourse.

In order to test in a dev build concourse, it's necessary to:
* configure the dev build concourse with a `CF_API`, `CF_USERNAME` and `CF_PASSWORD` pointing at a dev CF deployment.
* open up the dev CF deployments API security group to the dev build concourse.
* upload the rubbernecker secrets to the dev build concourse
* run the setup pipeline
* run the rubbernecker pipeline

🚨  Before merging...

* Merge https://github.com/alphagov/paas-rubbernecker/pull/28
* Remove the `TMP` commit here.

## Who can review

Not me.