### PR TITLE
Point to a secret file

### DIFF
--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -64,8 +64,6 @@ jobs:
           status: pending
       - task: run-tests
         params:
-          STATE_BUCKET: ((state_bucket))
-          AWS_REGION: ((aws_region))
           SECRETS_FILE: ((secrets_file))
         file: repo/ci/integration.yml
     on_success:
@@ -95,6 +93,8 @@ jobs:
         bump: minor
     - task: run-tests
       file: repo/ci/integration.yml
+      params:
+        SECRETS_FILE: ((secrets_file))
       on_success:
         put: resource-version
         params:


### PR DESCRIPTION
## What

As it turns out, the integration tests require some secrets in order to
connect to the compose API and run checks before creating a tag release.

This parameter should allow the script to obtain the path to it and fill
in the gaps.

## How to review

- Sanity check of the solution should be enough
- Optionally, in your dev build concourse, run the `compose-broker` and hope for it to be successful - I haven't done that step
