### PR TITLE
[#153091168] Use updated cf-cli docker container with autopilot plugin

### DIFF
--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -32,6 +32,7 @@ jobs:
             type: docker-image
             source:
               repository: ((app_deployment_docker_image))
+              tag: ((app_deployment_docker_image_tag))
           inputs:
             - name: ((app_name))
           run:
@@ -62,6 +63,7 @@ jobs:
             type: docker-image
             source:
               repository: ((app_deployment_docker_image))
+              tag: ((app_deployment_docker_image_tag))
           inputs:
             - name: ((app_name))
           outputs:

--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -95,7 +95,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: b70af5321b8c80994add887c94827aa583f95541
           inputs:
             - name: files-to-push
             - name: secrets

--- a/scripts/build-app-deployment-pipelines.sh
+++ b/scripts/build-app-deployment-pipelines.sh
@@ -15,6 +15,7 @@ app_name: ${APP_NAME}
 app_github_repo_uri: ${APP_REPOSITORY}
 app_repository_branch: ${APP_BRANCH}
 app_deployment_docker_image: ${APP_DOCKER_IMAGE}
+app_deployment_docker_image_tag: ${APP_DOCKER_IMAGE_TAG:-latest}
 cf_api: ${CF_API}
 cf_api_secure: ${CF_API_SECURE:-}
 cf_user: ${CF_USER}


### PR DESCRIPTION
**Advice:** *Merge this before the `paas-product-page` and `paas-tech-docs` PRs or else you will have to kick off their deploy pipelines manually.*

## What

* Use a new version of the `governmentpaas/cf-cli` Docker container that contains the autopilot `cf` plugin (see the already-merged https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/103.)
* Add ability to specify a docker image tag name for app deploys. This helped us and will aid future development work.

## How to review

* Code review.
* Use our build environment to test these changes. See the Pivotal story for details.
* 🐝 Remove the `TMP` commit before merging.

## Who can review

Not @46bit @camelpunch 