### PR TITLE
[#153697787] Set CF_APPS_DOMAIN and pass it to the deploy jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ci: globals ## Work on the ci account
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export CONCOURSE_ATC_PASSWORD_PASS_FILE=ci_deployments/build/concourse_password)
 	$(eval export CF_API=https://api.cloud.service.gov.uk)
+	$(eval export CF_APPS_DOMAIN=cloudapps.digital)
 	@true
 
 .PHONY: upload-cf-cli-secrets

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A pipeline should be created for each Bosh release this repository is currently 
 When you setup the pipelines in a dev environment they will be paused by default. You can manaully unpause the ones that you need to work on, but be aware that they will submit their results to GitHub pull requests.
 
 * Run `DEPLOY_ENV=... make dev upload-cf-cli-secrets`. You can override the credentials used by setting `CF_USER` and `CF_PASSWORD`.
-* Run `CF_API=... DEPLOY_ENV=... make dev pipelines`, where `CF_API` is the URL of your dev Cloud Foundry API.
+* Run `CF_API=... CF_APPS_DOMAIN=... DEPLOY_ENV=... make dev pipelines`, where `CF_API` is the URL of your dev Cloud Foundry API and `CF_APPS_DOMAIN` is the applications domain in your dev Cloud Foundry.
 * Run the setup pipeline.
 * Based on our current configuration your dev build CI will not be allowed to access your dev CloudFoundry API. This means you will have to manually allow the traffic in the AWS console.
 

--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -108,6 +108,7 @@ jobs:
             CF_PASSWORD: ((cf_password))
             CF_ORG: ((cf_org))
             CF_SPACE: ((cf_space))
+            CF_APPS_DOMAIN: ((cf_apps_domain))
             SECRETS_FILE: ((secrets_file))
           run:
             path: sh
@@ -118,6 +119,10 @@ jobs:
               - |
                 if [ -z "${CF_API}" ]; then
                   echo "\$CF_API is empty, cannot connect to CF API"
+                  exit 1
+                fi
+                if [ -z "${CF_APPS_DOMAIN}" ]; then
+                  echo "\$CF_APPS_DOMAIN is empty, cannot push to CF"
                   exit 1
                 fi
                 echo "Logging on to Cloudfoundry..."

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -72,6 +72,7 @@ jobs:
             STATE_BUCKET_NAME: ((state_bucket_name))
             RELEASES_BUCKET_NAME: ((releases_bucket_name))
             CF_API: ((cf_api))
+            CF_APPS_DOMAIN: ((cf_apps_domain))
           run:
             path: sh
             args:
@@ -246,6 +247,7 @@ jobs:
             CF_API_SECURE: ((cf_api_secure))
             CF_USER: ((cf_user))
             CF_PASSWORD: ((cf_password))
+            CF_APPS_DOMAIN: ((cf_apps_domain))
           run:
             path: sh
             args:

--- a/scripts/build-app-deployment-pipelines.sh
+++ b/scripts/build-app-deployment-pipelines.sh
@@ -25,6 +25,7 @@ cf_space: ${CF_SPACE:-${APP_CF_SPACE}}
 state_bucket: ${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 secrets_file: ${SECRETS_FILE:-no-secrets-needed}
+cf_apps_domain: ${CF_APPS_DOMAIN}
 EOF
 }
 

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -5,6 +5,10 @@ if [ -z "${CF_API:-}" ]; then
   echo "WARNING: \$CF_API not set, the app deployment pipelines will fail"
 fi
 
+if [ -z "${CF_APPS_DOMAIN:-}" ]; then
+  echo "WARNING: \$CF_APPS_DOMAIN not set, the app deployment pipelines will fail"
+fi
+
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && pwd)
 PIPELINES_DIR="${SCRIPTS_DIR}/../pipelines"
 
@@ -33,6 +37,7 @@ cf_api: ${CF_API:-}
 cf_api_secure: ${CF_API_SECURE:-}
 cf_user: ${CF_USER}
 cf_password: ${CF_PASSWORD}
+cf_apps_domain: ${CF_APPS_DOMAIN}
 EOF
 }
 


### PR DESCRIPTION
## What

Add CF_APPS_DOMAIN and pass it to the deploy jobs.

Currently the jobs like paas-product-page or paas-tech-docs use the production domain which makes testing in dev hard.

❗️ This PR contains a temporary commit to set the paas-product-page and paas-tech-docs projects to a dev branch. Please remove it before merging.

## How to review

1. Update your build Concourse:
   ```BRANCH=redirect_cf_domain_153697787 CF_API=https://api.${DEPLOYER_DEPLOY_ENV}.dev.cloudpipeline.digital CF_APPS_DOMAIN=${DEPLOYER_DEPLOY_ENV}.dev.cloudpipelineapps.digital SELF_UPDATE_PIPELINE=false make dev pipelines```
1. Change temporarily the ${DEPLOYER_DEPLOY_ENV}-cf-api security group to allow traffic from your build Concourse
1. Test the other PRs in this story:
   * https://github.com/alphagov/paas-tech-docs/pull/105
   * https://github.com/alphagov/paas-product-page/pull/47

## Who can review

Not @bandesz
