### PR TITLE
[#153561855] Add loggregator release pipeline

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -75,8 +75,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              repository: governmentpaas/bosh-cli-v2
+              tag: 2b4604fe69274908af304c15f28ca8dd657b0221
           inputs:
             - name: bosh-release-pr
           outputs:
@@ -94,12 +94,10 @@ jobs:
                 cd bosh-release-pr
 
                 VERSION=0.0.$(date +%s)
-                bosh create release \
-                  --name "${NAME}" \
+                bosh create-release \
                   --version "${VERSION}" \
-                  --with-tarball \
+                  --tarball "../bosh-release-tarballs/${NAME}-${VERSION}.tgz" \
                   --force
-                cp "dev_releases/${NAME}/${NAME}-${VERSION}.tgz" ../bosh-release-tarballs
                 ls -al ../bosh-release-tarballs
 
                 SHA1=$(openssl sha1 "../bosh-release-tarballs/${NAME}-${VERSION}.tgz" | cut -d' ' -f 2)
@@ -143,8 +141,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              repository: governmentpaas/bosh-cli-v2
+              tag: 2b4604fe69274908af304c15f28ca8dd657b0221
           inputs:
             - name: bosh-release-repo
             - name: bosh-release-version
@@ -163,12 +161,10 @@ jobs:
                 cd bosh-release-repo
 
                 VERSION=$(cat ../bosh-release-version/number)
-                bosh create release \
-                  --name "${NAME}" \
+                bosh create-release \
                   --version "${VERSION}" \
-                  --with-tarball \
+                  --tarball "../bosh-release-tarballs/${NAME}-${VERSION}.tgz" \
                   --force
-                cp "dev_releases/${NAME}/${NAME}-${VERSION}.tgz" ../bosh-release-tarballs
                 cp ../bosh-release-version/number ../bosh-release-tarballs/version
                 ls -al ../bosh-release-tarballs
 

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -58,4 +58,4 @@ setup_release_pipeline grafana alphagov/paas-grafana-boshrelease gds_master
 setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
 setup_release_pipeline routing alphagov/paas-routing-release gds_master
 setup_release_pipeline elasticache-broker alphagov/paas-elasticache-broker-boshrelease master
-setup_release_pipeline loggregator-release alphagov/paas-loggregator-release master
+setup_release_pipeline loggregator alphagov/paas-loggregator-release gds_master

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -58,3 +58,4 @@ setup_release_pipeline grafana alphagov/paas-grafana-boshrelease gds_master
 setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
 setup_release_pipeline routing alphagov/paas-routing-release gds_master
 setup_release_pipeline elasticache-broker alphagov/paas-elasticache-broker-boshrelease master
+setup_release_pipeline loggregator-release alphagov/paas-loggregator-release master

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -37,7 +37,7 @@ cf_api: ${CF_API:-}
 cf_api_secure: ${CF_API_SECURE:-}
 cf_user: ${CF_USER}
 cf_password: ${CF_PASSWORD}
-cf_apps_domain: ${CF_APPS_DOMAIN}
+cf_apps_domain: ${CF_APPS_DOMAIN:-}
 EOF
 }
 


### PR DESCRIPTION
## What

Adds the loggregator-release pipeline

We have to use a forked version of the loggregator-release to add a drain script.

Additional changes:
 - make the CF_APPS_DOMAIN really optional
 - Use Bosh CLI v2 for building BOSH releases (v1 was not able to handle sha256 checksums)

## How to review

Test as part of https://github.com/alphagov/paas-cf/pull/1183

## Who can review

Not @keymon or @bandesz