### PR TITLE
[#154524416] Rename paas-usage-events-collector to paas-billing

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -47,7 +47,14 @@ setup_test_pipeline() {
 
 }
 
+# FIXME: Remove when deployed.
+if $FLY_CMD -t "${FLY_TARGET}" pipelines | grep -qE "^usage-events-collector\s"; then
+  $FLY_CMD -t "${FLY_TARGET}" rename-pipeline \
+    -o usage-events-collector \
+    -n paas-billing
+fi
+
 setup_test_pipeline rds-broker alphagov paas-rds-broker master
 setup_test_pipeline compose-broker alphagov paas-compose-broker master compose-broker-secrets.yml
-setup_test_pipeline usage-events-collector alphagov paas-usage-events-collector master
+setup_test_pipeline paas-billing alphagov paas-billing master
 setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker master


### PR DESCRIPTION
## What

Rename paas-usage-events-collector to paas-billing

The old name was difficult to remember and didn't reflect the fact that
this app now has an API to reporting billing.

## How to review

1. Test with alphagov/paas-cf#
1. You can bring up your own build CI to test the renaming, but I've done it from scratch so you'd be excused for not repeating it.

🐝 🐝 🐝 **after merging:** 🐝 🐝 🐝 

1. Run the `setup` pipeline on https://concourse.build.ci.cloudpipeline.digital
1. Check that it has tested alphagov/paas-billing#

## Who can review

Anyone with access to Build Concourse in CI.