### PR TITLE
[#154524416] Remove FIXME for paas-billing rename

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -47,13 +47,6 @@ setup_test_pipeline() {
 
 }
 
-# FIXME: Remove when deployed.
-if $FLY_CMD -t "${FLY_TARGET}" pipelines | grep -qE "^usage-events-collector\s"; then
-  $FLY_CMD -t "${FLY_TARGET}" rename-pipeline \
-    -o usage-events-collector \
-    -n paas-billing
-fi
-
 setup_test_pipeline rds-broker alphagov paas-rds-broker master
 setup_test_pipeline compose-broker alphagov paas-compose-broker master compose-broker-secrets.yml
 setup_test_pipeline paas-billing alphagov paas-billing master


### PR DESCRIPTION
## What

Remove FIXME now that the paas-billing changes have been deployed to CI.

## How to review

1. Code review.
1. Confirm that the [existing pipeline has been renamed](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-billing).

## Who can review

@bandesz reviewed the original PRs, but anyone else can review this because it's relatively simple.