### PR TITLE
[#154249348] Remove --skip-ssl-validation flag in dev.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ dev: globals check-env-vars ## Work on the dev account
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export UNPAUSE_PIPELINES=false)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
-	$(eval export CF_API_SECURE=--skip-ssl-validation)
 	@true
 
 ci: globals ## Work on the ci account

--- a/pipelines/deploy-app.yml
+++ b/pipelines/deploy-app.yml
@@ -103,7 +103,6 @@ jobs:
             - name: secrets
           params:
             CF_API: ((cf_api))
-            CF_API_SECURE: ((cf_api_secure))
             CF_USER: ((cf_user))
             CF_PASSWORD: ((cf_password))
             CF_ORG: ((cf_org))
@@ -126,8 +125,8 @@ jobs:
                   exit 1
                 fi
                 echo "Logging on to Cloudfoundry..."
-                cf login "${CF_API_SECURE:-}" -a "${CF_API}" -u "${CF_USER}" \
-                -p "${CF_PASSWORD}" -o "${CF_ORG}" -s "${CF_SPACE}"
+                cf login -a "${CF_API}" -u "${CF_USER}" \
+                  -p "${CF_PASSWORD}" -o "${CF_ORG}" -s "${CF_SPACE}"
 
                 cd files-to-push
                 if [ -f release/push ]; then

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -244,7 +244,6 @@ jobs:
             STATE_BUCKET_NAME: ((state_bucket_name))
             RELEASES_BUCKET_NAME: ((releases_bucket_name))
             CF_API: ((cf_api))
-            CF_API_SECURE: ((cf_api_secure))
             CF_USER: ((cf_user))
             CF_PASSWORD: ((cf_password))
             CF_APPS_DOMAIN: ((cf_apps_domain))

--- a/scripts/build-app-deployment-pipelines.sh
+++ b/scripts/build-app-deployment-pipelines.sh
@@ -17,7 +17,6 @@ app_repository_branch: ${APP_BRANCH}
 app_deployment_docker_image: ${APP_DOCKER_IMAGE}
 app_deployment_docker_image_tag: ${APP_DOCKER_IMAGE_TAG:-latest}
 cf_api: ${CF_API}
-cf_api_secure: ${CF_API_SECURE:-}
 cf_user: ${CF_USER}
 cf_password: ${CF_PASSWORD}
 cf_org: ${CF_ORG:-${APP_CF_ORG}}

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -34,7 +34,6 @@ system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 pipeline_trigger_file: ${pipeline_name}.trigger
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 cf_api: ${CF_API:-}
-cf_api_secure: ${CF_API_SECURE:-}
 cf_user: ${CF_USER}
 cf_password: ${CF_PASSWORD}
 cf_apps_domain: ${CF_APPS_DOMAIN:-}


### PR DESCRIPTION
## What

Our dev environments are now using ACM provided certs, so this flag is
no longer needed.

## How to review

Code review may be enough. Verify that this only affects dev environments.

I've been using this in my dev build concourse to test deployments to my dev CF deployment.

## Who can review

Not me.