### PR TITLE
[#155178552] Explicitly set release name when creating release (and 2)

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -163,6 +163,7 @@ jobs:
 
                 VERSION=$(cat ../bosh-release-version/number)
                 bosh create-release \
+                  --name "${NAME}" \
                   --version "${VERSION}" \
                   --tarball "../bosh-release-tarballs/${NAME}-${VERSION}.tgz" \
                   --force


### PR DESCRIPTION
[#155178552 Monitor Redis queue length for ELK stack](https://www.pivotaltracker.com/story/show/155178552)

> **Note:** Same than fa60d8512699a8b7cfce21f9912dbf353c4fadbb but for the
master branch

What?
-----

After upgrading the bosh cli to v2 as part of the PR
alphagov/paas-release-ci#51 we dropped the option `--name`,
as it was not docummented online [1].

But after doing that, releases like datadog-for-cloudfoundry would
get a different name than before (e.g. paas-datadog-for-cloudfoundry
instead of datadog-for-cloudfoundry.

We add again the explicit option `--name` to fix this.

[1] https://bosh.io/docs/cli-v2.html

How to review?
-------------

 - Code review
 - trust me (AGAIN!), it works :)

Or:
   1. Rerun any build release job, e.g.: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/datadog-for-cloudfoundry-release/jobs/build-dev-release/builds/75
   2. Login in concourse and hijack the container:
```
fly login -t build-ci -c https://concourse.build.ci.cloudpipeline.digital
fly -t build-ci hijack -j datadog-for-cloudfoundry-release/build-dev-release
```
   3. Run manually the create release:
 ```
sh-release-pr

VERSION=0.0.$(date +%s)
bosh create-release \
	--name "${NAME}" \
	--version "${VERSION}" \
	--tarball "../bosh-release-tarballs/${NAME}-${VERSION}.tgz" \
	--force
```
   4. Check that the output reports `Name` without the `paas-` prefix.

Who?
----

Anyone but @keymon or @bandesz