### PR TITLE
[#186288969] Update to latest bosh-cli-v2 container

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -143,7 +143,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 2b4604fe69274908af304c15f28ca8dd657b0221
+              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
           inputs:
             - name: bosh-release-repo
             - name: bosh-release-version


### PR DESCRIPTION
## What

We have recently updated all our pipelines to use BOSH CLI v2 commands
and updated the bosh-cli-v2 image along the way.

To keep consistency with our other repos we are bumping the image used
here too.

## How to review

This is a tricky one to test since each bosh release will rely on the container. You may want to ensure running one or more of the bosh-related build jobs still run successfully.

## Who can review

Not @chrisfarms or @bandesz 
