### PR TITLE
Publish paas-team-manual to Github Pages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,15 @@
-## What
+What
+----
 
 Describe what you have changed and why.
 
-## How to review
+How to review
+-------------
 
 Describe the steps required to test the changes.
 
-## Who can review
+Who can review
+--------------
 
 Describe who can review the changes. Or more importantly, list the people
 that can't review, because they worked on it.

--- a/pipelines/plain_pipelines/paas-team-manual.yml
+++ b/pipelines/plain_pipelines/paas-team-manual.yml
@@ -1,0 +1,71 @@
+---
+
+resource_types:
+  - name: s3-iam
+    type: docker-image
+    source:
+      repository: governmentpaas/s3-resource
+      tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
+
+resources:
+  - name: paas-team-manual
+    type: git
+    source:
+      uri: https://github.com/alphagov/paas-team-manual.git
+      branch: tech-docs-template
+
+  - name: ssh-private-key
+    type: s3-iam
+    source:
+      bucket: ((state_bucket_name))
+      versioned_file: ci_build_tag_key
+      region_name: ((aws_region))
+
+jobs:
+  - name: publish
+    serial: true
+    plan:
+      - get: paas-team-manual
+        trigger: true
+      - get: ssh-private-key
+      - task: publish
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.5-slim
+          inputs:
+            - name: paas-team-manual
+            - name: ssh-private-key
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            AWS_ACCOUNT: ((aws_account))
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                #apk add --no-progress --update build-base libffi-dev git
+                apt-get update
+                apt-get install -y build-essential libffi-dev git libcurl4-openssl-dev
+
+                chmod 600 ssh-private-key/ci_build_tag_key
+                mkdir -p /root/.ssh
+                cp ssh-private-key/ci_build_tag_key /root/.ssh/id_rsa
+
+                git config --global push.default simple
+                git config --global user.email "paas-release-ci@${DEPLOY_ENV}.${AWS_ACCOUNT}"
+                git config --global user.name "PaaS Release CI server ${DEPLOY_ENV} in ${AWS_ACCOUNT}"
+                export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+
+                cd paas-team-manual
+
+                new_remote="$(git remote -v | sed -n 's|origin.*https://\([^/]*\)/\([^ ]*\).*fetch.*|git@\1:\2|p')"
+                git remote set-url origin "$new_remote"
+
+                bundle install
+                bundle exec rake publish


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156658598

What
----

We want to automatically upload the paas-team-manual to Github pages.

Add a pipeline that will build the paas-team-manual and push it as a github page.
Target URL: https://alphagov.github.io/paas-team-manual/

For simplicity we use the `rake publish` task directly, which requires run
git to create a branch for gh-pages and push it.

The job must:
- Install the dependencies for ruby, git and ssh
- Configure git+ssh: set user, ssh key, rewrite origin url...

We do install the dependencies in the job itself to keep the pipeline
simple and not worry to generate a new container only for this. This
task will rarely run and we do not mind some more time installing
dependencies.

We use ruby debian because it is easier to get the ruby dependencies
working (e.g. libv8 library is problematic on alpine).

We use the ci_build_tag_key configured in setup.sh

[1] https://pages.github.com/


How to review
-------------

 1. Fork the https://github.com/alphagov/paas-team-manual.git to your
 personal hithub and change the url in the pipeline.
 2. Generate a key with `ssh-keygen -f /tmp/foo.id_rsa`, upload it to S3
 `aws s3 cp /tmp/foo.id_rsa s3://gds-paas-${DEPLOY_ENV}-state/ci_build_tag_key`
 3. Add the key as deploy key with write access
 2. `~/gds/paas-cf/bin/fly -t ${DEPLOY_ENV} set-pipeline -c
 pipelines/plain_pipelines/paas-team-manual.yml -p paas-team-manual -v
 deploy_env=dev -v aws_account=dev -v aws_region=eu-west-1 -v
 state_bucket_name=gds-paas-${DEPLOY_ENV}-state`
 4. Try to run it



Who can review
--------------
Anyone but @keymon or @bandesz 