### PR TITLE
[#156922228] Add pipeline for paas-accounts

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -51,3 +51,4 @@ setup_test_pipeline rds-broker alphagov paas-rds-broker master
 setup_test_pipeline compose-broker alphagov paas-compose-broker master compose-broker-secrets.yml
 setup_test_pipeline paas-billing alphagov paas-billing master
 setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker master
+setup_test_pipeline paas-accounts alphagov paas-accounts master


### PR DESCRIPTION
What
----

paas-accounts is a mini service for storing details of PaaS
users/accounts that we cannot store within the platform itself.

This adds a pipeline for tagging merges to master as versioned releases.

How to review
-------------

Code review

Who can review
--------------

Not @chrisfarms or @dcarley 
