### PR TITLE
[#153119909] Upgrade Ruby to 2.5

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -76,7 +76,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 2b4604fe69274908af304c15f28ca8dd657b0221
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: bosh-release-pr
           outputs:
@@ -143,7 +143,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: bosh-release-repo
             - name: bosh-release-version

--- a/pipelines/plain_pipelines/paas-product-page.yml
+++ b/pipelines/plain_pipelines/paas-product-page.yml
@@ -34,7 +34,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: c6f8be180c0c98cc5ee7bd75d224e4b677faf74d
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: paas-product-page
             - name: zendesk-secrets

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -76,7 +76,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: b70af5321b8c80994add887c94827aa583f95541
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: files-to-push
           params:

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -98,7 +98,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: c6f8be180c0c98cc5ee7bd75d224e4b677faf74d
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: files-to-push
             - name: rubbernecker-secrets

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -76,7 +76,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: paas-release-ci
           params:
@@ -219,7 +219,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
           inputs:
             - name: paas-release-ci
           params:


### PR DESCRIPTION
## What

Update Ruby version to 2.5

We decided to use the same (latest) Ruby version everywhere. We still used 2.2 in multiple places which reached EOL on 2018-03-31 (#1), so we decided to migrate to the latest stable version.

We had to upgrade govuk-lint as older versions didn't support Ruby 2.5. Thanks to the upgrade we've got new style check violations but we decided to ignore them (at least for now), as this would unnecessarily blow up the story and increase the risk.

#1 https://www.ruby-lang.org/en/downloads/branches/

## How to review

1. Create a new CI env from scratch from this branch

```
BRANCH=upgrade_ruby_153119909 SELF_UPDATE_PIPELINE=false make dev build-concourse bootstrap
```

1. Upload the necessary secrets (see readme)

1. Update the pipeline

    ```
    BRANCH=upgrade_ruby_153119909 SELF_UPDATE_PIPELINE=false CF_DEPLOY_ENV=... 
    DEPLOY_ENV=... make dev pipelines
    ```

1. Run the setup pipeline

1. Run these plain pipelines: rubbernecker, tech-docs, product-page

1. Run one create BOSH release pipeline (e.g. rds-broker-release)

1. Destroy the env

## How to merge

❗️ The PR contains a WIP commit which needs to be updated with the final Docker image tags.

## Who can review

Not me.
