### PR TITLE
Update paas-pass path for rubbernecker pivotal token

### DIFF
--- a/scripts/upload-rubbernecker-secrets.sh
+++ b/scripts/upload-rubbernecker-secrets.sh
@@ -4,7 +4,7 @@ set -eu
 
 export PASSWORD_STORE_DIR=${RUBBERNECKER_PASSWORD_STORE_DIR}
 
-PIVOTAL_TRACKER_API_TOKEN=$(pass "pivotal/tracker_token")
+PIVOTAL_TRACKER_API_TOKEN=$(pass "pivotal/rubbernecker_api_token")
 PAGERDUTY_AUTHTOKEN=$(pass "pagerduty/rubbernecker_api_token")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)


### PR DESCRIPTION
What
----

This was renamed in the store[1], but this script wasn't updated to
account for the change

[1]https://github.com/alphagov/paas-credentials/commit/0030695

How to review
-------------

Code review. Optionally test the `upload-rubbernecker-secrets` task.

Who can review
--------------

Not me.