### PR TITLE
[#157084165] Add rds-metric-collector to integration pipelines

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -52,3 +52,4 @@ setup_test_pipeline compose-broker alphagov paas-compose-broker master compose-b
 setup_test_pipeline paas-billing alphagov paas-billing master
 setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker master
 setup_test_pipeline paas-accounts alphagov paas-accounts master
+setup_test_pipeline rds-metric-collector alphagov paas-rds-metric-collector master


### PR DESCRIPTION
What
----

This PR adds the new rds-metric-collector into the integration
testing and tagging pipeline process we use. The boshrelease is handles
as part of the RDS broker process as the two will coexist.

How to review
-------------

Code review should suffice. Feel free to push to a dev build concourse if you wish.

Who can review
--------------

Not @keymon or @LeePorte
