### PR TITLE
[#156721553] Enable paas-admin to receive version bump

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -53,3 +53,4 @@ setup_test_pipeline paas-billing alphagov paas-billing master
 setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker master
 setup_test_pipeline paas-accounts alphagov paas-accounts master
 setup_test_pipeline rds-metric-collector alphagov paas-rds-metric-collector master
+setup_test_pipeline paas-admin alphagov paas-admin master


### PR DESCRIPTION
What
----

In order to achieve automatic version bumpin, we'd need to add it to the
list of application that have integration tests build in.

How to review
-------------

- Make sure the change makes sense.

Dependencies
-------------

This PR is second in the chain of PRs.

Merge after the: alphagov/paas-admin#61
Merge before the: alphagov/paas-cf#1386