### PR TITLE
[#156368115] Remove graphite and grafana pipelines

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -49,12 +49,10 @@ setup_release_pipeline rds-broker alphagov/paas-rds-broker-boshrelease master
 setup_release_pipeline datadog-for-cloudfoundry alphagov/paas-datadog-for-cloudfoundry-boshrelease master
 setup_release_pipeline logsearch-for-cloudfoundry alphagov/paas-logsearch-for-cloudfoundry gds_master
 setup_release_pipeline paas-haproxy alphagov/paas-haproxy-release master
-setup_release_pipeline graphite alphagov/paas-graphite-statsd-boshrelease gds_master
 setup_release_pipeline collectd alphagov/paas-collectd-boshrelease gds_master
 setup_release_pipeline datadog-agent alphagov/paas-datadog-agent-boshrelease gds_master
 setup_release_pipeline syslog alphagov/paas-syslog-release gds_master
 setup_release_pipeline ipsec alphagov/paas-ipsec-release gds_master
-setup_release_pipeline grafana alphagov/paas-grafana-boshrelease gds_master
 setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
 setup_release_pipeline routing alphagov/paas-routing-release gds_master
 setup_release_pipeline elasticache-broker alphagov/paas-elasticache-broker-boshrelease master

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -45,6 +45,11 @@ setup_release_pipeline() {
     <(generate_vars_file)
 }
 
+remove_release_pipeline() {
+  pipeline_name="${1}-release"
+  ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" --non-interactive || true
+}
+
 setup_release_pipeline rds-broker alphagov/paas-rds-broker-boshrelease master
 setup_release_pipeline datadog-for-cloudfoundry alphagov/paas-datadog-for-cloudfoundry-boshrelease master
 setup_release_pipeline logsearch-for-cloudfoundry alphagov/paas-logsearch-for-cloudfoundry gds_master
@@ -57,3 +62,7 @@ setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
 setup_release_pipeline routing alphagov/paas-routing-release gds_master
 setup_release_pipeline elasticache-broker alphagov/paas-elasticache-broker-boshrelease master
 setup_release_pipeline loggregator alphagov/paas-loggregator-release gds_master
+
+## TODO: remove after the pipelines were deleted
+remove_release_pipeline graphite
+remove_release_pipeline grafana


### PR DESCRIPTION
## What

We decided to remove Graphite and Grafana, as we're mostly using Datadog for metrics collection and the effort required to maintain them doesn't seem worth it.

We don't need these pipelines anymore.

## How to review

Code review should be enough, I don't think it's worth to spin up a CI environment for this.

There is a quick-and-dirty test against your deployer Concourse:

```
CONCOURSE_URL=https://deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital/ make dev boshrelease-pipelines
```

but then you have to manually remove all the BOSH release pipelines:

```
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p rds-broker-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p datadog-for-cloudfoundry-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p logsearch-for-cloudfoundry-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p paas-haproxy-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p collectd-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p datadog-agent-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p syslog-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p ipsec-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p cdn-broker-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p routing-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p elasticache-broker-release -n
./bin/fly -t ${DEPLOY_ENV} destroy-pipeline -p loggregator-release -n
```

## Who can review

Not me.