### PR TITLE
[#157737869] Add Aiven broker to integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ upload-compose-secrets: check-env-vars ## Decrypt and upload Compose credentials
 	$(if $(wildcard ${COMPOSE_PASSWORD_STORE_DIR}),,$(error Password store ${COMPOSE_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-compose-secrets.sh
 
+.PHONY: upload-aiven-secrets
+upload-aiven-secrets: check-env-vars ## Decrypt and upload Compose credentials to S3
+	$(eval export AIVEN_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/ci))
+	$(if ${AIVEN_PASSWORD_STORE_DIR},,$(error Must pass _PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${AIVEN_PASSWORD_STORE_DIR}),,$(error Password store ${AIVEN_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-aiven-secrets.sh
+
 .PHONY: upload-zendesk-secrets
 upload-zendesk-secrets: check-env-vars ## Decrypt and upload Zendesk credentials to S3
 	$(eval export ZENDESK_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -55,3 +55,4 @@ setup_test_pipeline paas-accounts alphagov paas-accounts master
 setup_test_pipeline rds-metric-collector alphagov paas-rds-metric-collector master
 setup_test_pipeline paas-admin alphagov paas-admin master
 setup_test_pipeline paas-log-cache-adapter alphagov paas-log-cache-adapter master
+setup_test_pipeline aiven-broker alphagov paas-aiven-broker master aiven-broker-secrets.yml

--- a/scripts/upload-aiven-secrets.sh
+++ b/scripts/upload-aiven-secrets.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${AIVEN_PASSWORD_STORE_DIR}
+
+AIVEN_API_TOKEN=$(pass "aiven.io/${AWS_ACCOUNT}/api_token")
+AIVEN_PROJECT=$(pass "aiven.io/${AWS_ACCOUNT}/project_name")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+aiven_api_token: ${AIVEN_API_TOKEN}
+aiven_project: ${AIVEN_PROJECT}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/aiven-broker-secrets.yml"


### PR DESCRIPTION
What
----

These tests interact with the Aiven API and therefore require a token and the name of the project to put the service instances into.

The secrets have already been uploaded as part of the related pull request: https://github.com/alphagov/paas-credentials/pull/120

How to review
-------------

I recommend just code review and we can raise a new pull request if it requires changes. This is because spinning up a dev CI environment takes a very long time.

Who can review
--------------

Anyone but me or @samcrang 
