### PR TITLE
[#158353106] Enable log-cache-adapter to receive version bump

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -54,3 +54,4 @@ setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker master
 setup_test_pipeline paas-accounts alphagov paas-accounts master
 setup_test_pipeline rds-metric-collector alphagov paas-rds-metric-collector master
 setup_test_pipeline paas-admin alphagov paas-admin master
+setup_test_pipeline paas-log-cache-adapter alphagov paas-log-cache-adapter master


### PR DESCRIPTION
What
----

In order to achieve automatic version bumping, we'd need to add it to the
list of application that have integration tests build in.

How to review
-------------

- Sanity check

Dependencies
----

This is the second PR out of three.

Needs to be merged after: alphagov/paas-log-cache-adapter#2
Needs to be merged before: alphagov/paas-cf#1396