### PR TITLE
[#158943533] Tweak Aiven testing secrets upload for new projects.

### DIFF
--- a/scripts/upload-aiven-secrets.sh
+++ b/scripts/upload-aiven-secrets.sh
@@ -4,8 +4,7 @@ set -eu
 
 export PASSWORD_STORE_DIR=${AIVEN_PASSWORD_STORE_DIR}
 
-AIVEN_API_TOKEN=$(pass "aiven.io/${AWS_ACCOUNT}/api_token")
-AIVEN_PROJECT=$(pass "aiven.io/${AWS_ACCOUNT}/project_name")
+AIVEN_API_TOKEN=$(pass "aiven.io/ci/api_token")
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
@@ -13,7 +12,7 @@ trap 'rm  "${SECRETS}"' EXIT
 cat > "${SECRETS}" << EOF
 ---
 aiven_api_token: ${AIVEN_API_TOKEN}
-aiven_project: ${AIVEN_PROJECT}
+aiven_project: ci-testing
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/aiven-broker-secrets.yml"


### PR DESCRIPTION
## What

We now have a dedicated project in Aiven for running integration tests,
so this can be hard-coded in the upload script. We also hard-code the
pass path for the ci token as that's the one that has access to this
project.

How to review
-------------

Code review is probably enough. Compare with the corresponding credstore PRs.

## After merging

* Ensure the credstore PR is merged, and you've pulled latest master.
* Upload the Aiven creds (`make ci upload-aiven-secrets`)
* Verify the Aiven broker integration tests still work.

Who can review
--------------

Not me.