### PR TITLE
[#158180318] Upgrade fly-login wrapper to cope with Concourse 4 upgrade

### DIFF
--- a/scripts/fly_sync_and_login.sh
+++ b/scripts/fly_sync_and_login.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 # Required env vars
-# CONCOURSE_URL
-# CONCOURSE_ATC_USER
-# CONCOURSE_ATC_PASSWORD
-# FLY_CMD
-# FLY_TARGET
+# shellcheck disable=SC2086
+: $CONCOURSE_URL \
+  $CONCOURSE_ATC_USER \
+  $CONCOURSE_ATC_PASSWORD \
+  $FLY_CMD \
+  $FLY_TARGET
 
 fetch_fly() {
   echo "Downloading fly .."

--- a/scripts/fly_sync_and_login.sh
+++ b/scripts/fly_sync_and_login.sh
@@ -8,16 +8,40 @@ set -euo pipefail
 # FLY_CMD
 # FLY_TARGET
 
-FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
-echo "Downloading fly command..."
-if [ -f "$FLY_CMD" ]; then
-  timestamp_flag=1
+fetch_fly() {
+  echo "Downloading fly .."
+  FLY_CMD_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=$(uname | tr '[:upper:]' '[:lower:]')"
+  curl \
+    --progress-bar \
+    --location \
+    --fail \
+    --output "$FLY_CMD" \
+    "$FLY_CMD_URL"
+  chmod +x "$FLY_CMD"
+}
+
+fly_sync() {
+  echo "Doing fly sync .."
+  $FLY_CMD -t "${FLY_TARGET}" sync
+}
+
+fly_login() {
+  echo "Doing fly login .."
+  $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_ATC_USER}" -p "${CONCOURSE_ATC_PASSWORD}"
+}
+
+fly_is_runnable() {
+  [ -x "${FLY_CMD}" ]
+}
+
+if fly_is_runnable; then
+  if fly_login; then
+    fly_sync
+  else
+    fetch_fly
+    fly_login
+  fi
+else
+  fetch_fly
+  fly_login
 fi
-curl "$FLY_CMD_URL" -# -L -f ${timestamp_flag:+-z "$FLY_CMD"} -o "$FLY_CMD" -u "${CONCOURSE_ATC_USER}:${CONCOURSE_ATC_PASSWORD}"
-chmod +x "$FLY_CMD"
-
-echo "Doing fly login"
-$FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_ATC_USER}" -p "${CONCOURSE_ATC_PASSWORD}"
-
-echo "Doing fly sync"
-$FLY_CMD -t "${FLY_TARGET}" sync


### PR DESCRIPTION
What
----

A Concourse `fly` binary v3.x cannot, in every situation, `fly sync` itself to a v4.x version (see [1]).

This commit:

- changes our wrapper script's logic so that it *can* sync itself back and forth across these major versions and
- puts the logic into consumable functions, for clarity.

This removes our previous file timestamp-based logic, which isn't needed.

Finally, the script now exits early if any required envvars aren't set. Whilst orthogonal, this should be uncontroversial and "obviously" the right thing to do.

[1] https://concourse-ci.org/download.html#v400

How to review
-------------

1) code review

2) manual integration tests:

(**NB this may be a bit over-enthusiastic. You might just prefer to test a 3->4 upgrade instead of the full matrix**)

You're going to run a matrix test against each fly-binary and concourse version. You'll have 3 binaries+"file missing" for fly, and 2 concourse versions: 8 tests overall.

- Get v3.8, v4.0.0 and v4.2.1 `fly` binaries for your OS.
- Get a v3.8 and 4.2.1 Concourse. It doesn't really matter if they're a Build CI or not, as you won't be testing the CI function itself.
  - 4.2.1: `eu-west-1/alex-bld`
- For each Concourse version:
  - export the following envvars:

```
export CONCOURSE_URL=<fill in>
export CONCOURSE_ATC_USER=<fill in>
export CONCOURSE_ATC_PASSWORD=<fill in>
export FLY_CMD="./bin/fly"
export FLY_TARGET=<some-temporary-reference-to-this-concourse>
```

  - For each fly version, and also with a missing binary to simulate a bootstrap:
    - Put the file into place as `$REPO/bin/fly`, chmod+x'd
    - Run `./scripts/fly_sync_and_login.sh && ./bin/fly pipelines && echo SUCCESS && ./bin/fly --version`
    - check for SUCCESS, and that the resulting fly version matches the concourse you were targetting

Who can review
--------------

Not @jpluscplusm.