### PR TITLE
[#161544435] Build our own capi-release

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -63,3 +63,4 @@ setup_release_pipeline routing alphagov/paas-routing-release gds_master
 setup_release_pipeline elasticache-broker alphagov/paas-elasticache-broker-boshrelease master
 setup_release_pipeline loggregator alphagov/paas-loggregator-release gds_master
 setup_release_pipeline metric-exporter alphagov/paas-metric-exporter-boshrelease master
+setup_release_pipeline capi alphagov/paas-capi-release gds_master


### PR DESCRIPTION
What
----

We are having trouble running the capi-release[1]. One solution seems
to be rebuild our own release tarball, without changes.

Other option is to use precompile releases, but as commented
by @jpluscplusm

"our IA "2 eyes" continuous deployment "agreement" is based on the
potential for us to examine the code we're running in prod, and how that
interacts with upstream's CI process and security guarantees. In the
case of An Issue, could we 100% point at the code we're running?"

Because that, we decided to use our build release from code.

[1] https://cloudfoundry.slack.com/archives/C07C04W4Q/p1541779348165300
[2] https://github.com/cloudfoundry/cf-deployment/issues/663

How to review
-------------

Code review

Who can review
--------------

not me