### PR TITLE
[#162083591] Add helper script for pausing pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,11 @@ lint_yaml:
 .PHONY: lint_concourse
 lint_concourse:
 	./scripts/pipecleaner.py --fatal-warnings pipelines/*.yml
+
+.PHONY: pause-all-pipelines
+pause-all-pipelines:
+	./scripts/pause-pipelines.sh pause
+
+.PHONY: unpause-all-pipelines
+unpause-all-pipelines:
+	./scripts/pause-pipelines.sh unpause

--- a/README.md
+++ b/README.md
@@ -67,3 +67,12 @@ You can override some variables to customise the deployment:
 ## Accessing Concourse
 
 The `build` Concourse server is deployed in the CI account using its own Bosh. You can get information about the server using `make ci showenv` command. This will give you necessary information to log-in to the server.
+
+## Pausing Pipelines
+
+If you want to pause all pipelines when redeploying Concourse you can use:
+
+```bash
+DEPLOY_ENV=build make ci pause-all-pipelines
+DEPLOY_ENV=build make ci unpause-all-pipelines
+```

--- a/scripts/pause-pipelines.sh
+++ b/scripts/pause-pipelines.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu
+
+action="$1"
+pipeline="${2:-all}"
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# shellcheck disable=SC2091
+$("${SCRIPTS_DIR}/environment.sh")
+"${SCRIPTS_DIR}/fly_sync_and_login.sh"
+
+if [ "$pipeline" != "all" ]; then
+  $FLY_CMD -t "${FLY_TARGET}" "${action}-pipeline" -p "$pipeline"
+  exit 0
+fi
+
+pipelines=$($FLY_CMD -t "${FLY_TARGET}" pipelines --json | jq -r '.[].name')
+for pipeline in $pipelines; do
+  $FLY_CMD -t "${FLY_TARGET}" "${action}-pipeline" -p "$pipeline"
+done


### PR DESCRIPTION
What
----

We often want to redeploy Concourse, which can be disruptive when there
are many pipelines potentially running integration tests against 3rd
party APIs. These helpers will allow quick pausing and unpausing of all
pipelines, which I have needed to do several times in the past.

How to review
-------------

Run both `make` targets. I didn't test pausing a single pipeline, but added the logic out of a lack of self-control over scope creep.

Who can review
--------------

Anyone but me.