### PR TITLE
[#162275131] Rename networking-release to cf-networking

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -65,4 +65,4 @@ setup_release_pipeline loggregator alphagov/paas-loggregator-release gds_master
 setup_release_pipeline metric-exporter alphagov/paas-metric-exporter-boshrelease master
 setup_release_pipeline capi alphagov/paas-capi-release gds_master
 setup_release_pipeline bosh alphagov/paas-bosh gds_master
-setup_release_pipeline networking-release alphagov/cf-networking-release gds_master
+setup_release_pipeline cf-networking alphagov/cf-networking-release gds_master


### PR DESCRIPTION
What
----

We picked the wrong name. The release package must be called
cf-networking:

https://github.com/cloudfoundry/cf-networking-release/blob/develop/releases/cf-networking/cf-networking-2.8.0.yml#L1

How to review
-------------

Code review

Who can review
--------------

not me