### PR TITLE
[#SUPPORT] Reduce the check interval for all resources

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -12,17 +12,20 @@ groups:
 resource_types:
   - name: pull-request
     type: docker-image
+    check_every: 24h
     source:
       repository: jtarchie/pr
 
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: semver-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/semver-resource
       tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
@@ -30,6 +33,7 @@ resource_types:
 resources:
   - name: bosh-release-pr
     type: pull-request
+    check_every: 1m
     source:
       repo: ((github_repo))
       access_token: ((github_access_token))
@@ -38,12 +42,14 @@ resources:
 
   - name: bosh-release-repo
     type: git
+    check_every: 1m
     source:
       uri: ((github_repo_uri))
       branch: ((final_release_branch))
 
   - name: bosh-release-tarballs
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((releases_bucket_name))
       region_name: ((aws_region))
@@ -51,6 +57,7 @@ resources:
 
   - name: bosh-release-version
     type: semver-iam
+    check_every: 24h
     source:
       bucket: ((releases_bucket_name))
       region_name: ((aws_region))

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -2,12 +2,14 @@
 resource_types:
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: semver-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/semver-resource
       tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
@@ -15,6 +17,7 @@ resource_types:
 resources:
   - name: pipeline-trigger
     type: semver-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket_name))
       region_name: ((aws_region))
@@ -22,12 +25,14 @@ resources:
 
   - name: paas-release-ci
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-release-ci
       branch: ((branch_name))
 
   - name: release-ci-tfstate
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket_name))
       region_name: ((aws_region))

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -2,11 +2,13 @@
 resource_types:
   - name: pull-request
     type: docker-image
+    check_every: 24h
     source:
       repository: jtarchie/pr
 
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
@@ -14,6 +16,7 @@ resource_types:
 resources:
   - name: pr
     type: pull-request
+    check_every: 1m
     source:
       repo: ((github_repo))
       access_token: ((github_access_token))
@@ -22,6 +25,7 @@ resources:
 
   - name: release-repository
     type: git
+    check_every: 1m
     source:
       branch: ((tag_branch))
       ignore_paths:
@@ -31,6 +35,7 @@ resources:
 
   - name: resource-version
     type: semver
+    check_every: 24h
     source:
       branch: ((tag_branch))
       driver: git
@@ -42,6 +47,7 @@ resources:
 
   - name: secrets
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -2,6 +2,7 @@
 resource_types:
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
@@ -9,12 +10,14 @@ resource_types:
 resources:
   - name: paas-codimd
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-codimd
       branch: gds_master
 
   - name: hackmd-secrets
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))

--- a/pipelines/plain_pipelines/paas-product-page.yml
+++ b/pipelines/plain_pipelines/paas-product-page.yml
@@ -2,6 +2,7 @@
 resource_types:
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
@@ -9,12 +10,14 @@ resource_types:
 resources:
   - name: paas-product-page
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-product-page.git
       branch: master
 
   - name: zendesk-secrets
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))

--- a/pipelines/plain_pipelines/paas-team-manual.yml
+++ b/pipelines/plain_pipelines/paas-team-manual.yml
@@ -3,6 +3,7 @@
 resource_types:
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
@@ -10,12 +11,14 @@ resource_types:
 resources:
   - name: paas-team-manual
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-team-manual.git
       branch: master
 
   - name: ssh-private-key
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket))
       versioned_file: ci_build_tag_key

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -3,6 +3,7 @@
 resource_types:
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
@@ -10,6 +11,7 @@ resource_types:
 resources:
   - name: paas-tech-docs
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-tech-docs.git
       branch: master

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -2,6 +2,7 @@
 resource_types:
   - name: s3-iam
     type: docker-image
+    check_every: 24h
     source:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
@@ -9,12 +10,14 @@ resource_types:
 resources:
   - name: rubbernecker
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-rubbernecker.git
       branch: master
 
   - name: rubbernecker-secrets
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket))
       region_name: ((aws_region))

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -15,6 +15,7 @@ resource_types:
 resources:
   - name: pipeline-trigger
     type: semver-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket_name))
       region_name: ((aws_region))
@@ -22,12 +23,14 @@ resources:
 
   - name: paas-release-ci
     type: git
+    check_every: 1m
     source:
       uri: https://github.com/alphagov/paas-release-ci
       branch: ((branch_name))
 
   - name: release-ci-tfstate
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket_name))
       region_name: ((aws_region))
@@ -50,6 +53,7 @@ resources:
 
   - name: ssh-private-key
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket_name))
       versioned_file: ci_build_tag_key
@@ -58,6 +62,7 @@ resources:
 
   - name: ssh-public-key
     type: s3-iam
+    check_every: 24h
     source:
       bucket: ((state_bucket_name))
       versioned_file: ci_build_tag_key.pub


### PR DESCRIPTION
What
----

We are having load issues on our build CI, as all the resources
are checking for new versions across all the pipelines.

But we only want to check for those resources that trigger pipelines,
as the rest of the resources are checked as soon as each job is
triggered.

We will increase `check_every` to a big period for all non triggering
resources. We pick `24h`, to effectivelly disable the checks
on these resources.

For the resources that actually trigger the pipeline, we will keep
the default of 1m, but set it explicitelly to 1m.

More info:

[1] https://github.com/concourse/concourse/issues/1842
[2] https://github.com/concourse/concourse/issues/1445


How to review
-------------

Code review

Who can review
--------------

Not me