### PR TITLE
[#163263881] Add BOSH release pipeline for our bosh-aws-cpi-release fork

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -67,3 +67,4 @@ setup_release_pipeline cf-networking alphagov/cf-networking-release gds_master
 setup_release_pipeline concourse alphagov/paas-concourse-bosh-release gds_master
 setup_release_pipeline drone-agent-broker alphagov/paas-drone-agent-broker-boshrelease initial
 setup_release_pipeline prometheus alphagov/paas-prometheus-boshrelease gds_master
+setup_release_pipeline bosh-aws-cpi alphagov/paas-bosh-aws-cpi-release gds_master


### PR DESCRIPTION
What
----

We need to fork the AWS CPI to add support for the newer EC2 instance types. This adds the build pipeline for it.

How to review
-------------

Code review

Who can review
--------------

Not me.