### PR TITLE
Fix path to hackmd-secrets in hackmd build

### DIFF
--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -94,7 +94,7 @@ jobs:
 
                 spruce merge \
                   ./manifest-template.yml \
-                  ./hackmd-secrets/hackmd-secrets.yml |
+                  ../hackmd-secrets/hackmd-secrets.yml |
                   spruce merge --cherry-pick applications > manifest-prod.yml
 
                 cf zero-downtime-push hackmd -f ./manifest-prod.yml


### PR DESCRIPTION
What
----

This looks like it hasn't been tested since it was added - the last
hackmd build didn't use the secrets resource.

The path is wrong because there's a `cd` higher up in the script.

How to review
-------------

* Look at https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-hackmd/jobs/deploy/builds/12
* Code review

Who can review
--------------

Not @richardtowers