### PR TITLE
Add hackmd-db to the hackmd manifest

### DIFF
--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -79,7 +79,10 @@ jobs:
                   memory: 6G
                   instances: 1
                   stack: cflinuxfs3
+                  services:
+                    - hackmd-db
                   env:
+                    CF_DB: hackmd-db
                     PGSSLMODE: require
                     UV_THREADPOOL_SIZE: 100
                     CMD_PORT: 8080


### PR DESCRIPTION
What
----

`cf bgd` needs the apps to declare their bound services in their
manifests. It looks like this got lost in a refactoring at some point,
so putting it back in here.

From the git history it looks like we also need the CF_DB environment
variable setting.

How to review
-------------

* Code review

Who can review
--------------

* Not @richardtowers