### PR TITLE
Add a build for the S3 broker's release

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -69,3 +69,4 @@ setup_release_pipeline drone-agent-broker alphagov/paas-drone-agent-broker-boshr
 setup_release_pipeline prometheus alphagov/paas-prometheus-boshrelease gds_master
 setup_release_pipeline bosh-aws-cpi alphagov/paas-bosh-aws-cpi-release gds_master
 setup_release_pipeline log-cache alphagov/paas-log-cache-release gds_master
+setup_release_pipeline log-cache alphagov/paas-s3-broker-boshrelease master


### PR DESCRIPTION
What
----

https://github.com/alphagov/paas-s3-broker-boshrelease

At the moment the release is completely untested, so it's likely that it
will need a bit of iterating once it's enabled.

How to review
-------------

* Code review of this PR should be enough

Who can review
--------------

Not @tnwhitwell 
