### PR TITLE
Fix a flub in build-boshrelease-pipelines

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -69,4 +69,4 @@ setup_release_pipeline drone-agent-broker alphagov/paas-drone-agent-broker-boshr
 setup_release_pipeline prometheus alphagov/paas-prometheus-boshrelease gds_master
 setup_release_pipeline bosh-aws-cpi alphagov/paas-bosh-aws-cpi-release gds_master
 setup_release_pipeline log-cache alphagov/paas-log-cache-release gds_master
-setup_release_pipeline log-cache alphagov/paas-s3-broker-boshrelease master
+setup_release_pipeline s3-broker alphagov/paas-s3-broker-boshrelease master


### PR DESCRIPTION
What
----

In #99, s3-broker was added, but when duplicating the previous line, `log-cache` was not replaced with `s3-broker` meaning the log-cache job was replaced with the s3-broker one.

This fixes that.

How to review
-------------

Just a review of the changes.

Who can review
--------------

Not @tnwhitwell 
