### PR TITLE
Skip create-bosh-concourse when pausing pipelines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,9 @@ lint_concourse:
 	./scripts/pipecleaner.py --fatal-warnings pipelines/*.yml
 
 .PHONY: pause-all-pipelines
-pause-all-pipelines:
+pause-all-pipelines: ## Pause all pipelines so that create-bosh-concourse can be run safely.
 	./scripts/pause-pipelines.sh pause
 
 .PHONY: unpause-all-pipelines
-unpause-all-pipelines:
+unpause-all-pipelines: ## Unpause all pipelines after running create-bosh-concourse
 	./scripts/pause-pipelines.sh unpause

--- a/scripts/pause-pipelines.sh
+++ b/scripts/pause-pipelines.sh
@@ -17,5 +17,7 @@ fi
 
 pipelines=$($FLY_CMD -t "${FLY_TARGET}" pipelines --json | jq -r '.[].name')
 for pipeline in $pipelines; do
-  $FLY_CMD -t "${FLY_TARGET}" "${action}-pipeline" -p "$pipeline"
+  if [ "${pipeline}" != "create-bosh-concourse" ]; then
+    $FLY_CMD -t "${FLY_TARGET}" "${action}-pipeline" -p "$pipeline"
+  fi
 done


### PR DESCRIPTION
What
----

Pausing the pipelines is done so that create-bosh-concourse can be run
without causing problems. It therefore doesn't make sense to pause this
pipeline as it's the one that's about to be run.

I've also added help text for these targets so that they appear in the `make help` output.

How to review
-------------

* Code review.
* Check the `make help` output looks sensible
* Run `make ci pause-all-pipelines` and observe that all except `create-bosh-concourse` get paused.

Who can review
--------------

Not me.