### PR TITLE
Add Slack notifications when deploys from CI fail

### DIFF
--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -7,6 +7,11 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
+  - name: slack-notification-resource
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: paas-codimd
     type: git
@@ -22,6 +27,12 @@ resources:
       bucket: ((state_bucket))
       region_name: ((aws_region))
       versioned_file: hackmd-secrets.yml
+
+  - name: slack-notification
+    type: slack-notification-resource
+    source:
+      url: ((slack_webhook_url))
+
 jobs:
   - name: deploy
     serial: true
@@ -99,3 +110,7 @@ jobs:
                   spruce merge --cherry-pick applications > manifest-prod.yml
 
                 cf zero-downtime-push hackmd -f ./manifest-prod.yml
+        on_failure:
+          put: slack-notification
+          params:
+            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."

--- a/pipelines/plain_pipelines/paas-product-page.yml
+++ b/pipelines/plain_pipelines/paas-product-page.yml
@@ -7,6 +7,11 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
+  - name: slack-notification-resource
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: paas-product-page
     type: git
@@ -22,6 +27,11 @@ resources:
       bucket: ((state_bucket))
       region_name: ((aws_region))
       versioned_file: zendesk-secrets.yml
+
+  - name: slack-notification
+    type: slack-notification-resource
+    source:
+      url: ((slack_webhook_url))
 
 jobs:
   - name: deploy
@@ -103,3 +113,7 @@ jobs:
 
                 cf zero-downtime-push paas-product-page -f ./manifest.yml
                 cf zero-downtime-push paas-product-page-redirect -f ./manifest.yml
+        on_failure:
+          put: slack-notification
+          params:
+            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."

--- a/pipelines/plain_pipelines/paas-team-manual.yml
+++ b/pipelines/plain_pipelines/paas-team-manual.yml
@@ -8,6 +8,11 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
+  - name: slack-notification-resource
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: paas-team-manual
     type: git
@@ -23,6 +28,11 @@ resources:
       bucket: ((state_bucket))
       versioned_file: ci_build_tag_key
       region_name: ((aws_region))
+
+  - name: slack-notification
+    type: slack-notification-resource
+    source:
+      url: ((slack_webhook_url))
 
 jobs:
   - name: publish
@@ -72,3 +82,7 @@ jobs:
 
                 bundle install
                 bundle exec rake publish
+        on_failure:
+          put: slack-notification
+          params:
+            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -8,6 +8,11 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
+  - name: slack-notification-resource
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: paas-tech-docs
     type: git
@@ -15,6 +20,11 @@ resources:
     source:
       uri: https://github.com/alphagov/paas-tech-docs.git
       branch: master
+
+  - name: slack-notification
+    type: slack-notification-resource
+    source:
+      url: ((slack_webhook_url))
 
 jobs:
   - name: test
@@ -39,6 +49,10 @@ jobs:
               - -c
               - |
                 make -C paas-tech-docs test
+        on_failure: &slack_failure_notification
+          put: slack-notification
+          params:
+            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."
 
   - name: deploy
     serial: true
@@ -70,6 +84,7 @@ jobs:
                 echo "Copying files to destination..."
                 cp -pr "paas-tech-docs/." files-to-push
                 ls -l files-to-push
+        on_failure: *slack_failure_notification
 
       - task: push
         config:
@@ -133,3 +148,4 @@ jobs:
 
                 cf zero-downtime-push paas-tech-docs -f manifest.yml
                 cf zero-downtime-push paas-tech-docs-redirect -f manifest.yml
+        on_failure: *slack_failure_notification

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -7,6 +7,11 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
+  - name: slack-notification-resource
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: rubbernecker
     type: git
@@ -24,11 +29,17 @@ resources:
       versioned_file: rubbernecker-secrets.yml
       initial_version: "-"
 
+  - name: slack-notification
+    type: slack-notification-resource
+    source:
+      url: ((slack_webhook_url))
+
 jobs:
   - name: test
     plan:
       - get: rubbernecker
         trigger: true
+
       - task: test
         config:
           platform: linux
@@ -53,6 +64,10 @@ jobs:
                 cd ${PROJECT_DIR}
 
                 make dependencies test
+        on_failure: &slack_failure_notification
+          put: slack-notification
+          params:
+            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."
 
   - name: deploy
     serial: true
@@ -60,7 +75,9 @@ jobs:
       - get: rubbernecker
         passed: ['test']
         trigger: true
+
       - get: rubbernecker-secrets
+
       - task: build
         config:
           platform: linux
@@ -93,6 +110,7 @@ jobs:
                 echo "Copying files to destination..."
                 cp -pr . "${WORKDIR}/files-to-push"
                 ls -l "${WORKDIR}/files-to-push"
+        on_failure: *slack_failure_notification
 
       - task: push
         config:
@@ -154,3 +172,4 @@ jobs:
                   spruce merge --cherry-pick applications > manifest.yml
 
                 cf zero-downtime-push rubbernecker -f manifest.yml
+        on_failure: *slack_failure_notification

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -12,6 +12,11 @@ resource_types:
       repository: governmentpaas/semver-resource
       tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
+  - name: slack-notification-resource
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
 resources:
   - name: pipeline-trigger
     type: semver-iam
@@ -69,6 +74,11 @@ resources:
       region_name: ((aws_region))
       initial_version: "-"
 
+  - name: slack-notification
+    type: slack-notification-resource
+    source:
+      url: ((slack_webhook_url))
+
 jobs:
   - name: self-update
     plan:
@@ -91,6 +101,7 @@ jobs:
             MAKEFILE_ENV_TARGET: ((makefile_env_target))
             CONCOURSE_URL: ((concourse_url))
             GITHUB_ACCESS_TOKEN: ((github_access_token))
+            SLACK_WEBHOOK_URL: ((slack_webhook_url))
             STATE_BUCKET_NAME: ((state_bucket_name))
             RELEASES_BUCKET_NAME: ((releases_bucket_name))
             CF_APPS_DOMAIN: ((cf_apps_domain))
@@ -109,6 +120,10 @@ jobs:
 
                   make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" pipelines
                 fi
+        on_failure: &slack_failure_notification
+          put: slack-notification
+          params:
+            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."
       - put: pipeline-trigger
         params: {bump: patch}
 
@@ -155,6 +170,7 @@ jobs:
           put: release-ci-tfstate
           params:
             file: updated-release-ci-tfstate/release-ci.tfstate
+        on_failure: *slack_failure_notification
 
   - name: generate-ssh-keys
     serial: true
@@ -208,6 +224,7 @@ jobs:
               - put: ssh-public-key
                 params:
                   file: generated-ssh-public-key/ci_build_tag_key.pub
+        on_failure: *slack_failure_notification
 
   - name: dynamic-pipelines
     plan:
@@ -234,6 +251,7 @@ jobs:
             CONCOURSE_ATC_PASSWORD: ((concourse_atc_password))
             CONCOURSE_URL: ((concourse_url))
             GITHUB_ACCESS_TOKEN: ((github_access_token))
+            SLACK_WEBHOOK_URL: ((slack_webhook_url))
             STATE_BUCKET_NAME: ((state_bucket_name))
             RELEASES_BUCKET_NAME: ((releases_bucket_name))
             CF_USER: ((cf_user))
@@ -250,3 +268,4 @@ jobs:
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" boshrelease-pipelines
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" integration-test-pipelines
                 make -C ./paas-release-ci "${MAKEFILE_ENV_TARGET}" plain-pipelines
+        on_failure: *slack_failure_notification

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -23,6 +23,7 @@ releases_bucket_name: ${RELEASES_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases}
 releases_blobs_bucket_name: ${RELEASES_BLOBS_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases-blobs}
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 github_status_context: ${DEPLOY_ENV}/status
+slack_webhook_url: ${SLACK_WEBHOOK_URL}
 boshrelease_name: ${boshrelease_name}
 github_repo: ${github_repo}
 github_repo_uri: https://github.com/${github_repo}

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -33,6 +33,7 @@ concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 pipeline_trigger_file: ${pipeline_name}.trigger
 github_access_token: ${GITHUB_ACCESS_TOKEN}
+slack_webhook_url: ${SLACK_WEBHOOK_URL}
 cf_user: ${CF_USER}
 cf_password: ${CF_PASSWORD}
 cf_apps_domain: ${CF_APPS_DOMAIN:-}

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -29,6 +29,10 @@ if [ -z "${GITHUB_ACCESS_TOKEN:-}" ]; then
   GITHUB_ACCESS_TOKEN=$(pass github.com/release_ci_pr_status_token)
 fi
 
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+  SLACK_WEBHOOK_URL=$(pass gds.slack.com/concourse_slack_webhook_url)
+fi
+
 if [ -z "${CF_USER:-}" ]; then
   if aws s3 ls "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" > /dev/null; then
     CF_USER=$(scripts/val_from_yaml.rb secrets.cf_user <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/cf-cli-secrets.yml" -))
@@ -51,6 +55,7 @@ export CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER}
 export CONCOURSE_ATC_PASSWORD=${CONCOURSE_ATC_PASSWORD}
 export CONCOURSE_URL=${CONCOURSE_URL}
 export GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN}
+export SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
 export FLY_CMD=${FLY_CMD}
 export FLY_TARGET=${FLY_TARGET}
 export CF_USER=${CF_USER}

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -15,6 +15,7 @@ SSH_KEY=$(aws s3 cp s3://"${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}"/ci
 pipeline_name: ${pipeline_name}
 github_access_token: ${GITHUB_ACCESS_TOKEN}
 github_status_context: ${DEPLOY_ENV}/status
+slack_webhook_url: ${SLACK_WEBHOOK_URL}
 state_bucket: ${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 branch_name: ${BRANCH:-master}

--- a/scripts/plain-pipelines.sh
+++ b/scripts/plain-pipelines.sh
@@ -18,6 +18,7 @@ state_bucket: ${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 cf_apps_domain: ${CF_APPS_DOMAIN}
 cf_system_domain: ${CF_SYSTEM_DOMAIN}
+slack_webhook_url: ${SLACK_WEBHOOK_URL}
 EOF
 }
 


### PR DESCRIPTION
What
----

Get Slack notifications when things deployed by our build CI fail to deploy.

Recently runs 186, 188, 189, 190, 191, 194, 196, 197, 198, 199, 201, 204 and 205 of the `paas-tech-docs` release pipeline failed, delaying some changes from going live by as much as two weeks!

See commit message for many more details.

How to review
-------------

* Code review;
* Review alongside https://github.com/alphagov/paas-credentials/pull/148

Who can review
--------------

Not @46bit