### PR TITLE
[#165715568] Adds paas-service-broker-base repo to integration tests list

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -63,3 +63,4 @@ setup_test_pipeline paas-admin alphagov paas-admin master
 setup_test_pipeline paas-log-cache-adapter alphagov paas-log-cache-adapter master
 setup_test_pipeline aiven-broker alphagov paas-aiven-broker master aiven-broker-secrets.yml
 setup_test_pipeline s3-broker alphagov paas-s3-broker master
+setup_test_pipeline paas-service-broker-base alphagov paas-service-broker-base master


### PR DESCRIPTION
What
----
Adds paas-service-broker-base repo to integration tests list, so that its tests can be run in Concourse rather than Travis

## 🚨DO NOT MERGE OR REVIEW UNTIL.. 🚨 
https://github.com/alphagov/paas-service-broker-base/pull/2 is merged. It contains the necessary Concourse task 

How to review
-------------
1. Code review
2. Deploy to a local build concourse and test?

Who can review
--------------
Anyone