### PR TITLE
Fix release name for cflinuxfs3

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -73,4 +73,4 @@ setup_release_pipeline log-cache alphagov/paas-log-cache-release gds_master
 setup_release_pipeline s3-broker alphagov/paas-s3-broker-boshrelease master
 setup_release_pipeline uaa-customized alphagov/paas-uaa-customized-boshrelease master
 setup_release_pipeline paas-uaa alphagov/paas-uaa-release gds_master
-setup_release_pipeline paas-cflinuxfs3-release alphagov/paas-cflinuxfs3-release gds_master
+setup_release_pipeline cflinuxfs3 alphagov/paas-cflinuxfs3-release gds_master


### PR DESCRIPTION
What
----

The release name needs to be cflinuxfs3 exactly. Doesn't work with the
prefix and suffix.

How to review
-------------

* Code review is enough

Who can review
--------------

Not @richardtowers