### PR TITLE
[#166351405] Rename the awslogs boshrelease for clarity

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -74,4 +74,4 @@ setup_release_pipeline s3-broker alphagov/paas-s3-broker-boshrelease master
 setup_release_pipeline uaa-customized alphagov/paas-uaa-customized-boshrelease master
 setup_release_pipeline paas-uaa alphagov/paas-uaa-release gds_master
 setup_release_pipeline cflinuxfs3 alphagov/paas-cflinuxfs3-release gds_master
-setup_release_pipeline cf-awslogs alphagov/paas-cf-awslogs-boshrelease gds_master
+setup_release_pipeline awslogs alphagov/paas-awslogs-boshrelease gds_master


### PR DESCRIPTION
What
----

https://github.com/alphagov/paas-cf-awslogs-boshrelease renamed to https://github.com/alphagov/paas-awslogs-boshrelease because we have made it more generic and the longer name was unreadable.

How to review
-------------

Code review

Who can review
--------------

Not @46bit