### PR TITLE
Remove old, unused boshrelease pipelines

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -52,21 +52,14 @@ remove_release_pipeline() {
 }
 
 setup_release_pipeline rds-broker alphagov/paas-rds-broker-boshrelease master
-setup_release_pipeline logsearch-for-cloudfoundry alphagov/paas-logsearch-for-cloudfoundry gds_master
 setup_release_pipeline paas-haproxy alphagov/paas-haproxy-release master
-setup_release_pipeline collectd alphagov/paas-collectd-boshrelease gds_master
-setup_release_pipeline syslog alphagov/paas-syslog-release gds_master
 setup_release_pipeline ipsec alphagov/paas-ipsec-release gds_master
 setup_release_pipeline cdn-broker alphagov/paas-cdn-broker-boshrelease master
-setup_release_pipeline routing alphagov/paas-routing-release gds_master
 setup_release_pipeline elasticache-broker alphagov/paas-elasticache-broker-boshrelease master
-setup_release_pipeline loggregator alphagov/paas-loggregator-release gds_master
 setup_release_pipeline metric-exporter alphagov/paas-metric-exporter-boshrelease master
 setup_release_pipeline capi alphagov/paas-capi-release gds_master
 setup_release_pipeline bosh alphagov/paas-bosh gds_master
-setup_release_pipeline cf-networking alphagov/cf-networking-release gds_master
 setup_release_pipeline concourse alphagov/paas-concourse-bosh-release gds_master
-setup_release_pipeline drone-agent-broker alphagov/paas-drone-agent-broker-boshrelease initial
 setup_release_pipeline prometheus alphagov/paas-prometheus-boshrelease gds_master
 setup_release_pipeline bosh-aws-cpi alphagov/paas-bosh-aws-cpi-release gds_master
 setup_release_pipeline log-cache alphagov/paas-log-cache-release gds_master


### PR DESCRIPTION
What
----

The boshrelease pipelines removed by this commit are no longer used.

• https://github.com/alphagov/paas-logsearch-for-cloudfoundry hasn't been updated in years and we use upstream.
• https://github.com/alphagov/paas-collectd-boshrelease hasn't been updated in years, only our Prometheus seems to use collectd, and it uses a separate project entirely.
• https://github.com/alphagov/paas-routing-release again isn't used.
• https://github.com/alphagov/paas-loggregator-release again isn't used.

**FIXME:** *I found extra ones that this also commit removes.*

How to review
-------------

Check we aren't relying on these.

## After merging

* Delete or archive the github repos;
* Manually delete the pipelines from our build concourse.

Who can review
--------------

Not @46bit.