### PR TITLE
Update paas-uaa-release pipeline's release name

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -72,7 +72,7 @@ setup_release_pipeline bosh-aws-cpi alphagov/paas-bosh-aws-cpi-release gds_maste
 setup_release_pipeline log-cache alphagov/paas-log-cache-release gds_master
 setup_release_pipeline s3-broker alphagov/paas-s3-broker-boshrelease master
 setup_release_pipeline uaa-customized alphagov/paas-uaa-customized-boshrelease master
-setup_release_pipeline paas-uaa alphagov/paas-uaa-release gds_master
+setup_release_pipeline uaa alphagov/paas-uaa-release gds_master
 setup_release_pipeline cflinuxfs3 alphagov/paas-cflinuxfs3-release gds_master
 setup_release_pipeline awslogs alphagov/paas-awslogs-boshrelease gds_master
 setup_release_pipeline oauth2-proxy alphagov/paas-oauth2-proxy-boshrelease gds_master


### PR DESCRIPTION
What
----

cf-deploy currently fails when using the paas-uaa-release as it expects the release name to be uaa. This changes the name from paas-uaa to uaa.

How to review
-------------

Code review

Who can review
--------------

Not me
