### PR TITLE
[#167804765] Expose VERSION as environment variable

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -101,6 +101,7 @@ jobs:
                 cd bosh-release-pr
 
                 VERSION=0.0.$(date +%s)
+                export VERSION
                 bosh create-release \
                   --name "${NAME}" \
                   --version "${VERSION}" \
@@ -169,6 +170,7 @@ jobs:
                 cd bosh-release-repo
 
                 VERSION=$(cat ../bosh-release-version/number)
+                export VERSION
                 bosh create-release \
                   --name "${NAME}" \
                   --version "${VERSION}" \


### PR DESCRIPTION
What
----

Exposing the version as an environment variable will help plumb together UAA in https://github.com/alphagov/paas-uaa-release/commit/20e64e877592ddfe9d64770402c353066160bba4#diff-e084dd0a5cbd5fccbb1ff2ef0e946e05R26-R32

How to review
-------------

Code review.

Who can review
--------------

Not @46bit. @tlwr might know if there's already a BOSH env variable available to `pre_packaging` with this in?