### PR TITLE
Use concourse secret in credhub for pipelines

### DIFF
--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -96,6 +96,8 @@ jobs:
           inputs:
             - name: paas-release-ci
           params:
+            CONCOURSE_WEB_USER: admin
+            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
             SELF_UPDATE_PIPELINE: ((self_update_pipeline))
             DEPLOY_ENV: ((deploy_env))
             BRANCH: ((branch_name))
@@ -250,6 +252,7 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
             BRANCH: ((branch_name))
             MAKEFILE_ENV_TARGET: ((makefile_env_target))
+            CONCOURSE_WEB_USER: admin
             CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
             CONCOURSE_URL: ((concourse_url))
             GITHUB_ACCESS_TOKEN: ((github_access_token))

--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -15,7 +15,6 @@ aws_account: ${AWS_ACCOUNT:-dev}
 deploy_env: ${DEPLOY_ENV}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-concourse_web_password: ${CONCOURSE_WEB_PASSWORD}
 concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 aws_account: ${AWS_ACCOUNT}

--- a/scripts/deploy-setup-pipelines.sh
+++ b/scripts/deploy-setup-pipelines.sh
@@ -28,7 +28,6 @@ releases_bucket_name: ${RELEASES_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases}
 releases_blobs_bucket_name: ${RELEASES_BLOBS_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-releases-blobs}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
-concourse_web_password: ${CONCOURSE_WEB_PASSWORD}
 concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 pipeline_trigger_file: ${pipeline_name}.trigger

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -20,11 +20,6 @@ CONCOURSE_URL="${CONCOURSE_URL:-https://concourse.${SYSTEM_DNS_ZONE_NAME}}"
 FLY_TARGET=${FLY_TARGET:-$DEPLOY_ENV}
 FLY_CMD="${FLY_DIR}/fly"
 
-CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER:-admin}
-if [ -z "${CONCOURSE_WEB_PASSWORD:-}" ]; then
-  CONCOURSE_WEB_PASSWORD=$(scripts/val_from_yaml.rb secrets.concourse_web_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
-fi
-
 if [ -z "${GITHUB_ACCESS_TOKEN:-}" ]; then
   GITHUB_ACCESS_TOKEN=$(pass github.com/release_ci_pr_status_token)
 fi
@@ -51,8 +46,6 @@ fi
 cat <<EOF
 export AWS_ACCOUNT=${AWS_ACCOUNT}
 export DEPLOY_ENV=${DEPLOY_ENV}
-export CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER}
-export CONCOURSE_WEB_PASSWORD=${CONCOURSE_WEB_PASSWORD}
 export CONCOURSE_URL=${CONCOURSE_URL}
 export GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN}
 export SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}

--- a/scripts/fly_sync_and_login.sh
+++ b/scripts/fly_sync_and_login.sh
@@ -4,10 +4,16 @@ set -euo pipefail
 # Required env vars
 # shellcheck disable=SC2086
 : $CONCOURSE_URL \
-  $CONCOURSE_WEB_USER \
-  $CONCOURSE_WEB_PASSWORD \
   $FLY_CMD \
   $FLY_TARGET
+
+if [ "$USER" == "root" ] ; then
+  # We are running in Concourse
+  # Required env vars
+  # shellcheck disable=SC2086
+  : $CONCOURSE_WEB_USER \
+    $CONCOURSE_WEB_PASSWORD
+fi
 
 fetch_fly() {
   echo "Downloading fly .."
@@ -28,8 +34,17 @@ fly_sync() {
 
 fly_login() {
   echo "Doing fly login .."
-  $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_WEB_USER}" -p "${CONCOURSE_WEB_PASSWORD}"
+  if [ "$USER" == "root" ] ; then
+    # We are running in Concourse
+    $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_WEB_USER}" -p "${CONCOURSE_WEB_PASSWORD}"
+  else
+    # We are running from our computer
+    # Check if we are logged in, if we aren't then use the browser
+    $FLY_CMD -t "${FLY_TARGET}" status || \
+      $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}"
+  fi
 }
+
 
 fly_is_runnable() {
   [ -x "${FLY_CMD}" ]


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/168427704)

🐝 This is contingent on https://github.com/alphagov/paas-bootstrap/pull/307 🐝 

What
----

Get concourse to use the secret in credhub instead of one in S3

How to review
-------------

I bootstrapped a Concourse and got it to self-update pipelines:

![image](https://user-images.githubusercontent.com/1482692/65615984-2df95b00-dfb2-11e9-8583-82ca96a6e7a3.png)

Who can review
--------------

Not @tlwr
