### PR TITLE
[#166501543] Build Docker Containers In Concourse

### DIFF
--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -1,0 +1,433 @@
+resources:
+- name: paas-docker-cloudfoundry-tools
+  type: git
+  source:
+    uri: https://github.com/alphagov/paas-docker-cloudfoundry-tools.git
+    branch: master
+
+- name: paas-tech-docs
+  type: git
+  source:
+    uri: https://github.com/alphagov/paas-tech-docs.git
+    branch: master
+
+- name: paas-semver-resource
+  type: git
+  source:
+    uri: https://github.com/alphagov/paas-semver-resource.git
+    branch: gds_master
+
+- name: psql
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: ((dockerhub_username))/psql
+
+- name: spruce
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/spruce
+
+- name: json-minify
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/json-minify
+
+- name: terraform
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/terraform
+
+- name: self-update-pipelines
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/self-update-pipelines
+
+- name: git-ssh
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/git-ssh
+
+- name: curl-ssl
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/curl-ssl
+
+- name: cf-cli
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/cf-cli
+
+- name: cf-acceptance-tests
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/cf-acceptance-tests
+
+- name: cf-uaac
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/cf-uaac
+
+- name: certstrap
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/certstrap
+
+- name: bosh-shell
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/bosh-shell
+
+- name: bosh
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/bosh
+
+- name: bosh-cli-v2
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/bosh-cli-v2
+
+- name: awscli
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/awscli
+
+- name: tech-docs
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/tech-docs
+
+- name: semver-resource
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/semver-resource
+
+jobs:
+- name: build-psql
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/psql
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            cut -d : -f 2 image/digest > image/tag
+  - put: psql
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-spruce
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/spruce
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: spruce
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-json-minify
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/json-minify
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: json-minify
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-terraform
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/terraform
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: terraform
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-self-update-pipelines
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/self-update-pipelines
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: self-update-pipelines
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-git-ssh
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/git-ssh
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: git-ssh
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-curl-ssl
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/curl-ssl
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: curl-ssl
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-cf-cli
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/cf-cli
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: cf-cli
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-cf-acceptance-tests
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/cf-acceptance-tests
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: cf-acceptance-tests
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-cf-uaac
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/cf-uaac
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: cf-uaac
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-certstrap
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/certstrap
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: certstrap
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-bosh-shell
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/bosh-shell
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: bosh-shell
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-bosh
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/bosh
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: bosh
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-bosh-cli-v2
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/bosh-cli-v2
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: bosh-cli-v2
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-awscli
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/awscli
+  - task: create-image-tag
+    config: *create-image-tag
+  - put: awscli
+    params:
+      image: image/image.tar
+      additional_tags: image/tag
+
+- name: build-paas-tech-docs
+  plan:
+  - get: paas-tech-docs
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-tech-docs
+        path: .
+      outputs:
+      - name: image
+      run:
+        path: build
+  - put: tech-docs
+    params:
+      image: image/image.tar
+
+- name: build-paas-semver-resource
+  plan:
+  - get: paas-semver-resource
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-semver-resource
+        path: .
+      outputs:
+      - name: image
+      run:
+        path: build
+  - put: semver-resource
+    params:
+      image: image/image.tar

--- a/pipelines/plain_pipelines/build-docker-pull-requests.yml
+++ b/pipelines/plain_pipelines/build-docker-pull-requests.yml
@@ -1,0 +1,852 @@
+resource_types:
+  - name: pull-request
+    type: docker-image
+    check_every: 24h
+    source:
+      repository: jtarchie/pr
+
+resources:
+- name: paas-docker-cloudfoundry-tools-pr
+  type: pull-request
+  check_every: 1m
+  source:
+    repo: alphagov/paas-docker-cloudfoundry-tools
+    access_token: ((github_access_token))
+    every: true
+    disable_forks: true
+
+- name: paas-tech-docs-pr
+  type: pull-request
+  check_every: 1m
+  source:
+    repo: alphagov/paas-tech-docs
+    access_token: ((github_access_token))
+    every: true
+    disable_forks: true
+
+- name: paas-semver-resource-pr
+  type: pull-request
+  check_every: 1m
+  source:
+    repo: alphagov/paas-semver-resource
+    access_token: ((github_access_token))
+    every: true
+    disable_forks: true
+
+- name: psql
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: ((dockerhub_username))/psql
+    tag: pr-build
+
+- name: spruce
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/spruce
+
+- name: json-minify
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/json-minify
+
+- name: terraform
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/terraform
+
+- name: self-update-pipelines
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/self-update-pipelines
+
+- name: git-ssh
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/git-ssh
+
+- name: curl-ssl
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/curl-ssl
+
+- name: cf-cli
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/cf-cli
+
+- name: cf-acceptance-tests
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/cf-acceptance-tests
+
+- name: cf-uaac
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/cf-uaac
+
+- name: certstrap
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/certstrap
+
+- name: bosh-shell
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/bosh-shell
+
+- name: bosh
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/bosh
+
+- name: bosh-cli-v2
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/bosh-cli-v2
+
+- name: awscli
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/awscli
+
+- name: tech-docs
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/tech-docs
+
+- name: semver-resource
+  type: registry-image
+  source:
+    <<: *build-image-source
+    repository: ((dockerhub_username))/semver-resource
+
+jobs:
+- name: build-psql-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/psql
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            cut -d : -f 2 image/digest > image/sha
+            cd paas-docker-cloudfoundry-tools-pr && git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /' > ../image/branch
+            cat ../image/sha ../image/branch | tr -d '\n' > ../image/tags
+    on_success:
+      do:
+        - put: psql
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-spruce-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/spruce
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: spruce
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-json-minify-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/json-minify
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: json-minify
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-terraform-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/terraform
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: terraform
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-self-update-pipelines-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/self-update-pipelines
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: self-update-pipelines
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-git-ssh-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/git-ssh
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: git-ssh
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-curl-ssl-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/curl-ssl
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: curl-ssl
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-cf-cli-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/cf-cli
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: cf-cli
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-cf-acceptance-tests-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/cf-acceptance-tests
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: cf-acceptance-tests
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-cf-uaac-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/cf-uaac
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: cf-uaac
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-certstrap-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/certstrap
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: certstrap
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-bosh-shell-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/bosh-shell
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: bosh-shell
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-bosh-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/bosh
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: bosh
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-bosh-cli-v2-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/bosh-cli-v2
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: bosh-cli-v2
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-awscli-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+  - put: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      <<: *build-image-config
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/awscli
+  - task: create-image-tag
+    config: *create-image-tag
+    on_success:
+      do:
+        - put: awscli
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-paas-tech-pr
+  serial: true
+  plan:
+  - get: paas-tech-docs-pr
+    version: every
+    trigger: true
+  - put: paas-tech-docs-pr
+    params:
+      path: paas-tech-docs-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-tech-docs-pr
+        path: .
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-tech-docs-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            cd paas-tech-docs-pr && git rev-parse --abbrev-ref HEAD > ../image/branch
+    on_success:
+      do:
+        - put: tech-docs
+          params:
+            image: image/image.tar
+            additional_tags: image/branch
+        - put: paas-tech-docs-pr
+          params:
+            path: paas-tech-docs-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-tech-docs-pr
+      params:
+        path: paas-tech-docs-pr
+        context: ((github_status_context))
+        status: failure
+
+- name: build-paas-semver-resource-pr
+  serial: true
+  plan:
+  - get: paas-semver-resource-pr
+    version: every
+    trigger: true
+  - put: paas-semver-resource-pr
+    params:
+      path: paas-semver-resource-pr
+      context: ((github_status_context))
+      status: pending
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-semver-resource-pr
+        path: .
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-semver-resource-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            cd paas-semver-resource-pr && git rev-parse --abbrev-ref HEAD > ../image/branch
+    on_success:
+      do:
+        - put: semver-resource
+          params:
+            image: image/image.tar
+            additional_tags: image/branch
+        - put: paas-semver-resource-pr
+          params:
+            path: paas-semver-resource-pr
+            context: ((github_status_context))
+            status: success
+    on_failure:
+      put: paas-semver-resource-pr
+      params:
+        path: paas-semver-resource-pr
+        context: ((github_status_context))
+        status: failure

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -43,6 +43,14 @@ if [ -z "${CF_PASSWORD:-}" ]; then
   fi
 fi
 
+if [ -z "${DOCKERHUB_USERNAME:-}" ]; then
+  DOCKERHUB_USERNAME=$(pass dockerhub/ci/id)
+fi
+
+if [ -z "${DOCKERHUB_PASSWORD:-}" ]; then
+  DOCKERHUB_PASSWORD=$(pass dockerhub/ci/password)
+fi
+
 cat <<EOF
 export AWS_ACCOUNT=${AWS_ACCOUNT}
 export DEPLOY_ENV=${DEPLOY_ENV}
@@ -53,4 +61,6 @@ export FLY_CMD=${FLY_CMD}
 export FLY_TARGET=${FLY_TARGET}
 export CF_USER=${CF_USER}
 export CF_PASSWORD=${CF_PASSWORD}
+export DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME}
+export DOCKERHUB_PASSWORD=${DOCKERHUB_PASSWORD}
 EOF

--- a/scripts/plain-pipelines.sh
+++ b/scripts/plain-pipelines.sh
@@ -19,6 +19,10 @@ aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 cf_apps_domain: ${CF_APPS_DOMAIN}
 cf_system_domain: ${CF_SYSTEM_DOMAIN}
 slack_webhook_url: ${SLACK_WEBHOOK_URL}
+dockerhub_username: ${DOCKERHUB_USERNAME}
+dockerhub_password: ${DOCKERHUB_PASSWORD}
+github_access_token: ${GITHUB_ACCESS_TOKEN}
+github_status_context: ${DEPLOY_ENV}/status
 EOF
 }
 


### PR DESCRIPTION
What
----

This adds two pipelines that build docker containers to our build concourse.
This is so we can migrate from Docker Hub's Automated Builds.

`build-docker-containers.yml` is triggered when a branch is merged to
master. `build-docker-pull-requests.yml` is triggered when a pull request is
raised and tags the image with pr-build, pr-branch-name and hash. `pr-build` is
specified because the registry-image-resource defaults to latest.

In order to push the images to Docker Hub, this adds the username/password from
the password store.

How to review
-------------

- Code review
- Test using mobuild concourse or build concourse. If using mobuild, let me know so I can provide the dockerhub details.

Who can review
--------------

Not me
