### PR TITLE
Pipeline must install paas-tech-docs dependencies

### DIFF
--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -48,7 +48,9 @@ jobs:
               - -u
               - -c
               - |
-                make -C paas-tech-docs dependencies test
+                cd paas-tech-docs
+                bundle install
+                make test
         on_failure: &slack_failure_notification
           put: slack-notification
           params:
@@ -79,7 +81,9 @@ jobs:
               - -u
               - -c
               - |
-                make -C paas-tech-docs dependencies build
+                cd paas-tech-docs
+                bundle install
+                make build
 
                 echo "Copying files to destination..."
                 cp -pr "paas-tech-docs/." files-to-push

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -48,7 +48,7 @@ jobs:
               - -u
               - -c
               - |
-                make -C paas-tech-docs test
+                make -C paas-tech-docs dependencies test
         on_failure: &slack_failure_notification
           put: slack-notification
           params:
@@ -79,7 +79,7 @@ jobs:
               - -u
               - -c
               - |
-                make -C paas-tech-docs build
+                make -C paas-tech-docs dependencies build
 
                 echo "Copying files to destination..."
                 cp -pr "paas-tech-docs/." files-to-push


### PR DESCRIPTION
What
----

Since [merging a gem upgrade](https://github.com/alphagov/paas-tech-docs/pull/288) the `paas-tech-docs` pipelines on the build concourse have [been failing](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-tech-docs/jobs/test/builds/10) with errors like the following:

> bundle exec middleman build
> Could not find rack-2.1.1 in any of the sources
> Run `bundle install` to install missing gems.

It turns out that `paas-tech-docs` has a `dependencies` Make target that the pipeline wasn't invoking.

I checked locally and there are no `Gemfile.lock` changes made when invoking it, so I don't think that it's a problem with `paas-tech-docs`. I'm *guessing* that this worked until now because the Gems being used happened to be in the Docker container.

How to review
-------------

See that it works!

❌ Before: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-tech-docs/jobs/test/builds/11

✅ After: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-tech-docs/jobs/test/builds/13

Who can review
--------------

Not @46bit.