### PR TITLE
Further fix the paas-tech-docs pipeline

### DIFF
--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -85,6 +85,7 @@ jobs:
                 bundle install
                 make build
 
+                cd ..
                 echo "Copying files to destination..."
                 cp -pr "paas-tech-docs/." files-to-push
                 ls -l files-to-push


### PR DESCRIPTION
What
----

Carries on from #133. This fix is hacky but `cp -pr "." files-to-push` failed and it isn't worth the time to investigate.

How to review
-------------

See that it fixed things when I deployed it.

❌ Before: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-tech-docs/jobs/deploy/builds/11

✅ https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-tech-docs/jobs/deploy/builds/12

Who can review
--------------

Not @46bit.