### PR TITLE
Do not bother with a pipeline for IPSec

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -57,7 +57,6 @@ setup_release_pipeline bosh-aws-cpi       alphagov/paas-bosh-aws-cpi-release    
 setup_release_pipeline capi               alphagov/paas-capi-release                   gds_master
 setup_release_pipeline cflinuxfs3         alphagov/paas-cflinuxfs3-release             gds_master
 setup_release_pipeline concourse          alphagov/paas-concourse-bosh-release         gds_master
-setup_release_pipeline ipsec              alphagov/paas-ipsec-release                  gds_master
 setup_release_pipeline oauth2-proxy       alphagov/paas-oauth2-proxy-boshrelease       gds_master
 setup_release_pipeline prometheus         alphagov/paas-prometheus-boshrelease         gds_master
 setup_release_pipeline routing            alphagov/paas-routing-release                gds_master


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/164728382)

What
----

See See https://github.com/alphagov/paas-cf/pull/2281

We do not need this pipeline anymore, and the repo has been archived

How to review
-------------

Code review

Check that [the search for ipsec in concourse](https://concourse.build.ci.cloudpipeline.digital/?search=ipsec) returns no pipelines

Who can review
--------------

Not @tlwr
