### PR TITLE
Tune CodiMD pipeline

### DIFF
--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -108,6 +108,12 @@ jobs:
                   sleep 30
                 done
 
+                cf create-service aws-s3-bucket default hackmd-store -c '{"public_bucket":true}'
+                while ! cf service hackmd-store | grep -q 'create succeeded'; do
+                  echo "Waiting for creation of service to complete..."
+                  sleep 5
+                done
+
                 echo "Generating manifest template"
                 cat <<EOF | tee manifest-template.yml
                 ---
@@ -121,6 +127,7 @@ jobs:
                   stack: cflinuxfs3
                   services:
                     - hackmd-db
+                    - hackmd-store
                   env:
                     CF_DB: hackmd-db
                     PGSSLMODE: require
@@ -131,6 +138,7 @@ jobs:
                     CMD_DOMAIN: 'hackmd.${CF_APPS_DOMAIN}'
                     CMD_PROTOCOL_USESSL: 'true'
                     CMD_ALLOW_ORIGIN: 'localhost,hackmd.${CF_APPS_DOMAIN},cdnjs.cloudflare.com,fonts.googleapis.com,fonts.gstatic.com'
+                    CMD_IMAGE_UPLOAD_TYPE: s3
                 EOF
 
                 spruce merge \
@@ -139,6 +147,8 @@ jobs:
                   spruce merge --cherry-pick applications > manifest-prod.yml
 
                 cf zero-downtime-push hackmd -f ./manifest-prod.yml
+
+                cf bind-service hackmd hackmd-store -c '{"permissions": "read-write"}'
         on_failure:
           put: slack-notification
           params:

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -40,6 +40,34 @@ jobs:
       - get: paas-codimd
         trigger: true
       - get: hackmd-secrets
+
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: node
+              tag: 10
+          inputs:
+          - name: paas-codimd
+          outputs:
+          - name: paas-codimd
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                cd paas-codimd
+
+                echo "Installing application dependencies..."
+                npm install
+
+                echo "Building application assets..."
+                npm run build
+
       - task: push
         config:
           platform: linux
@@ -66,7 +94,7 @@ jobs:
               - -u
               - -c
               - |
-                echo "Logging on to Cloudfoundry..."
+                echo "Logging on to CloudFoundry..."
                 cf login \
                   -a "${CF_API}" \
                   -u "${CF_USER}" \
@@ -85,7 +113,8 @@ jobs:
                 ---
                 applications:
                 - name: hackmd
-                  buildpack: nodejs_buildpack
+                  buildpacks:
+                    - nodejs_buildpack
                   path: ./paas-codimd/
                   memory: 6G
                   instances: 1

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -139,6 +139,7 @@ jobs:
                     CMD_PROTOCOL_USESSL: 'true'
                     CMD_ALLOW_ORIGIN: 'localhost,hackmd.${CF_APPS_DOMAIN},cdnjs.cloudflare.com,fonts.googleapis.com,fonts.gstatic.com'
                     CMD_IMAGE_UPLOAD_TYPE: s3
+                    CMD_SESSION_SECRET: (( grab hackmd_session_secret ))
                 EOF
 
                 spruce merge \

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -75,7 +75,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/cf-cli
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: latest
           inputs:
             - name: paas-codimd
             - name: hackmd-secrets
@@ -107,49 +107,26 @@ jobs:
                   echo "Waiting for creation of service to complete..."
                   sleep 30
                 done
+                cf bind-service hackmd hackmd-db
 
                 cf create-service aws-s3-bucket default hackmd-store -c '{"public_bucket":true}'
                 while ! cf service hackmd-store | grep -q 'create succeeded'; do
                   echo "Waiting for creation of service to complete..."
                   sleep 5
                 done
+                cf bind-service hackmd hackmd-store -c '{"permissions": "read-write"}'
 
-                echo "Generating manifest template"
-                cat <<EOF | tee manifest-template.yml
+                echo "Generating manifest variables"
+                cat <<EOF | tee paas-codimd/vars.yml
                 ---
-                applications:
-                - name: hackmd
-                  buildpacks:
-                    - nodejs_buildpack
-                  path: ./paas-codimd/
-                  memory: 6G
-                  instances: 1
-                  stack: cflinuxfs3
-                  services:
-                    - hackmd-db
-                    - hackmd-store
-                  env:
-                    CF_DB: hackmd-db
-                    PGSSLMODE: require
-                    UV_THREADPOOL_SIZE: 100
-                    CMD_PORT: 8080
-                    CMD_GITHUB_CLIENTID: (( grab hackmd_client_id  ))
-                    CMD_GITHUB_CLIENTSECRET: (( grab hackmd_client_secret ))
-                    CMD_DOMAIN: 'hackmd.${CF_APPS_DOMAIN}'
-                    CMD_PROTOCOL_USESSL: 'true'
-                    CMD_ALLOW_ORIGIN: 'localhost,hackmd.${CF_APPS_DOMAIN},cdnjs.cloudflare.com,fonts.googleapis.com,fonts.gstatic.com'
-                    CMD_IMAGE_UPLOAD_TYPE: s3
-                    CMD_SESSION_SECRET: (( grab hackmd_session_secret ))
+                domain: ${CF_APPS_DOMAIN}
+                github_client_id: $(grep hackmd_client_id hackmd-secrets/hackmd-secrets.yml | awk '{print $2}')
+                github_client_secret: $(grep hackmd_client_secret hackmd-secrets/hackmd-secrets.yml | awk '{print $2}')
+                secret: $(grep hackmd_session_secret hackmd-secrets/hackmd-secrets.yml | awk '{print $2}')
                 EOF
 
-                spruce merge \
-                  ./manifest-template.yml \
-                  ./hackmd-secrets/hackmd-secrets.yml |
-                  spruce merge --cherry-pick applications > manifest-prod.yml
-
-                cf zero-downtime-push hackmd -f ./manifest-prod.yml
-
-                cf bind-service hackmd hackmd-store -c '{"permissions": "read-write"}'
+                cd paas-codimd
+                cf push hackmd --vars-file vars.yml
         on_failure:
           put: slack-notification
           params:

--- a/scripts/upload-secrets/upload-hackmd-secrets.sh
+++ b/scripts/upload-secrets/upload-hackmd-secrets.sh
@@ -6,6 +6,7 @@ export PASSWORD_STORE_DIR=${HACKMD_PASSWORD_STORE_DIR}
 
 HACKMD_CLIENT_ID=$(pass "github.com/hackmd/github_client_id")
 HACKMD_CLIENT_SECRET=$(pass "github.com/hackmd/github_client_secret")
+HACKMD_SESSION_SECRET=$(date +%s | sha256sum | base64 | head -c 64 ; echo)
 
 SECRETS=$(mktemp secrets.yml.XXXXXX)
 trap 'rm  "${SECRETS}"' EXIT
@@ -14,6 +15,7 @@ cat > "${SECRETS}" << EOF
 ---
 hackmd_client_id: ${HACKMD_CLIENT_ID}
 hackmd_client_secret: ${HACKMD_CLIENT_SECRET}
+hackmd_session_secret: ${HACKMD_SESSION_SECRET}
 EOF
 
 aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/hackmd-secrets.yml"


### PR DESCRIPTION
What
----

Some of the assets need to be pre-built before pushing them up, as
`nodejs_builtpack` does not install devDependencies on staging, therefore
is incapable of building the project.

At the moment, each re-deployment of an application will delete the
uploads provided from the users. This should be fixed, when we use S3
for storage purpose.

We're going to be generating a new secret everytime we run
`make upload-hackmd-secrets`, meaning we have an easy way to rotate the
secret, but also ensure that the secret persist in the bucket for long
enough, to be pulled out and used by the application itself, to use for
session encryption.

This should ensure, that restarting or re-scheduling the application
will not log everyone out at all times. It also means, we can have more
than a single instance of CodiMD running at once, increasing it's
reliability.

How to review
-------------

Easiest way, would be to test in prod 😄 

1. Run `make upload-hackmd-secrets` in production
1. Make sure alphagov/paas-codimd `gds_master` has been force pushed to a new one (currently called `new-gds-master`)
1. Manually apply this pipeline in our CI
1. Run the `paas-hackmd` pipeline
1. See it succeed
1. Navigate to hackmd and attempt to use it
