### PR TITLE
Remove references to secrets file from integration test pipeline

### DIFF
--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -45,20 +45,10 @@ resources:
       private_key: ((tagging_key))
       uri: ((github_repo_uri))
 
-  - name: secrets
-    type: s3-iam
-    check_every: 24h
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: ((secrets_file))
-      initial_version: "-"
-
 jobs:
   - name: integration-test
     serial: true
     plan:
-      - get: secrets
       - get: repo
         resource: pr
         version: every
@@ -70,8 +60,6 @@ jobs:
           context: ((github_status_context))
           status: pending
       - task: run-tests
-        params:
-          SECRETS_FILE: ((secrets_file))
         file: repo/ci/integration.yml
     on_success:
       put: repo
@@ -94,14 +82,11 @@ jobs:
     - get: repo
       resource: release-repository
       trigger: true
-    - get: secrets
     - get: resource-version
       params:
         bump: minor
     - task: run-tests
       file: repo/ci/integration.yml
-      params:
-        SECRETS_FILE: ((secrets_file))
       on_success:
         put: resource-version
         params:

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -25,7 +25,6 @@ github_repo: ${organisation}/${repository}
 github_repo_uri: git@github.com:${organisation}/${repository}.git
 tag_branch: ${tag_branch}
 version_file: ${version_file}
-secrets_file: ${secrets_file}
 EOF
 echo -e "tagging_key: |\n  ${SSH_KEY//$'\n'/$'\n'  }"
 }
@@ -36,8 +35,6 @@ setup_test_pipeline() {
   organisation="$2"
   repository="$3"
   tag_branch="$4"
-  secrets_file="${5:-no-secrets-needed}"
-
 
   generate_vars_file > /dev/null # Check for missing vars
 

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -59,7 +59,7 @@ setup_test_pipeline paas-auditor alphagov paas-auditor master
 setup_test_pipeline rds-metric-collector alphagov paas-rds-metric-collector master
 setup_test_pipeline paas-admin alphagov paas-admin master
 setup_test_pipeline paas-log-cache-adapter alphagov paas-log-cache-adapter master
-setup_test_pipeline aiven-broker alphagov paas-aiven-broker integation-tests-use-credhub
+setup_test_pipeline aiven-broker alphagov paas-aiven-broker master
 setup_test_pipeline s3-broker alphagov paas-s3-broker master
 setup_test_pipeline paas-service-broker-base alphagov paas-service-broker-base master
 setup_test_pipeline paas-trusted-people alphagov paas-trusted-people master


### PR DESCRIPTION
What
----
Now that we're uploading the secrets that used to live in S3 to Credhub, we no
longer need to pass the secrets file to the integration tests task file, or
mention it at all in the pipeline.

Also changes the branch for the aiven broker tests back to `master`.

How to review
-------------

1. Code review
2. See that [this aiven broker PR has paased](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/aiven-broker/jobs/integration-test/builds/5) based on [this commit](https://github.com/alphagov/paas-aiven-broker/pull/23/commits/feb8e2d7e31df007d7c79d01bc8199c07249dce6)

Who can review
--------------
Anyone

