### PR TITLE
Build PaaS product pages

### DIFF
--- a/pipelines/plain_pipelines/paas-product-pages.yml
+++ b/pipelines/plain_pipelines/paas-product-pages.yml
@@ -21,6 +21,12 @@ resources:
 jobs:
   - name: deploy
     serial: true
+
+    on_failure:
+      put: slack-notification
+      params:
+        text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."
+
     plan:
       - get: paas-product-pages
         trigger: true
@@ -83,7 +89,3 @@ jobs:
                   -s "${CF_SPACE}"
 
                 cf zero-downtime-push paas-product-pages -f ./manifest.yml
-        on_failure:
-          put: slack-notification
-          params:
-            text: "Job $BUILD_NAME in $BUILD_JOB_NAME on $BUILD_PIPELINE_NAME failed. Check the logs at $ATC_EXTERNAL_URL/builds/$BUILD_ID."

--- a/pipelines/plain_pipelines/paas-product-pages.yml
+++ b/pipelines/plain_pipelines/paas-product-pages.yml
@@ -25,6 +25,29 @@ jobs:
       - get: paas-product-pages
         trigger: true
 
+      - task: build
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: node
+              tag: lts
+          inputs:
+            - name: paas-product-pages
+          outputs:
+            - name: paas-product-pages
+          run:
+            dir: paas-product-pages
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                npm install
+                node "$(npm bin)/next" build && node "$(npm bin)/next" export
+
       - task: push
         config:
           platform: linux


### PR DESCRIPTION
What
----

- Add a task to build the static app
- Move on_failure hook to job level, so it fails for either build or push

How to review
-------------

Check [the pipeline](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-product-pages/jobs/deploy/builds/6) is green

Who can review
--------------

@kr8n3r 
