### PR TITLE
Use github-pr-resource instead of jtarchie/pr

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -14,7 +14,8 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: jtarchie/pr
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
 
   - name: s3-iam
     type: docker-image
@@ -35,7 +36,7 @@ resources:
     type: pull-request
     check_every: 1m
     source:
-      repo: ((github_repo))
+      repository: ((github_repo))
       access_token: ((github_access_token))
       every: true
       disable_forks: true

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -4,7 +4,8 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: jtarchie/pr
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
 
   - name: s3-iam
     type: docker-image
@@ -18,7 +19,7 @@ resources:
     type: pull-request
     check_every: 1m
     source:
-      repo: ((github_repo))
+      repository: ((github_repo))
       access_token: ((github_access_token))
       every: true
       disable_forks: true

--- a/pipelines/plain_pipelines/build-docker-pull-requests.yml
+++ b/pipelines/plain_pipelines/build-docker-pull-requests.yml
@@ -3,14 +3,15 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: jtarchie/pr
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
 
 resources:
 - name: paas-docker-cloudfoundry-tools-pr
   type: pull-request
   check_every: 1m
   source:
-    repo: alphagov/paas-docker-cloudfoundry-tools
+    repository: alphagov/paas-docker-cloudfoundry-tools
     access_token: ((github_access_token))
     every: true
     disable_forks: true
@@ -19,7 +20,7 @@ resources:
   type: pull-request
   check_every: 1m
   source:
-    repo: alphagov/paas-tech-docs
+    repository: alphagov/paas-tech-docs
     access_token: ((github_access_token))
     every: true
     disable_forks: true
@@ -28,7 +29,7 @@ resources:
   type: pull-request
   check_every: 1m
   source:
-    repo: alphagov/paas-semver-resource
+    repository: alphagov/paas-semver-resource
     access_token: ((github_access_token))
     every: true
     disable_forks: true


### PR DESCRIPTION
What
----

[jtarchie/pr](https://github.com/jtarchie/github-pullrequest-resource) is deprecated

teliaoss/github-pr-resource now supports disabling forks, so we can use it instead

Read https://github.com/telia-oss/github-pr-resource#migrating