### PR TITLE
Trigger docker build when HEAD changes, and tag images according to branch

### DIFF
--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -158,11 +158,17 @@ jobs:
           - -u
           - -c
           - |
-            cut -d : -f 2 image/digest > image/tag
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name},${git_commit_sha}" > image/tags
   - put: psql
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-spruce
   plan:
@@ -178,7 +184,7 @@ jobs:
   - put: spruce
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-json-minify
   plan:
@@ -194,7 +200,7 @@ jobs:
   - put: json-minify
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-terraform
   plan:
@@ -210,7 +216,7 @@ jobs:
   - put: terraform
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-self-update-pipelines
   plan:
@@ -226,7 +232,7 @@ jobs:
   - put: self-update-pipelines
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-git-ssh
   plan:
@@ -242,7 +248,7 @@ jobs:
   - put: git-ssh
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-curl-ssl
   plan:
@@ -258,7 +264,7 @@ jobs:
   - put: curl-ssl
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-cf-cli
   plan:
@@ -274,7 +280,7 @@ jobs:
   - put: cf-cli
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-cf-acceptance-tests
   plan:
@@ -290,7 +296,7 @@ jobs:
   - put: cf-acceptance-tests
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-cf-uaac
   plan:
@@ -306,7 +312,7 @@ jobs:
   - put: cf-uaac
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-certstrap
   plan:
@@ -322,7 +328,7 @@ jobs:
   - put: certstrap
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-bosh-shell
   plan:
@@ -338,7 +344,7 @@ jobs:
   - put: bosh-shell
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-bosh
   plan:
@@ -354,7 +360,7 @@ jobs:
   - put: bosh
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-bosh-cli-v2
   plan:
@@ -370,7 +376,7 @@ jobs:
   - put: bosh-cli-v2
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-awscli
   plan:
@@ -386,7 +392,7 @@ jobs:
   - put: awscli
     params:
       image: image/image.tar
-      additional_tags: image/tag
+      additional_tags: image/tags
 
 - name: build-paas-tech-docs
   plan:

--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -124,6 +124,7 @@ jobs:
 - name: build-psql
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config: &build-image-config
@@ -173,6 +174,7 @@ jobs:
 - name: build-spruce
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -189,6 +191,7 @@ jobs:
 - name: build-json-minify
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -205,6 +208,7 @@ jobs:
 - name: build-terraform
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -221,6 +225,7 @@ jobs:
 - name: build-self-update-pipelines
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -237,6 +242,7 @@ jobs:
 - name: build-git-ssh
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -253,6 +259,7 @@ jobs:
 - name: build-curl-ssl
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -269,6 +276,7 @@ jobs:
 - name: build-cf-cli
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -285,6 +293,7 @@ jobs:
 - name: build-cf-acceptance-tests
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -301,6 +310,7 @@ jobs:
 - name: build-cf-uaac
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -317,6 +327,7 @@ jobs:
 - name: build-certstrap
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -333,6 +344,7 @@ jobs:
 - name: build-bosh-shell
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -349,6 +361,7 @@ jobs:
 - name: build-bosh
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -365,6 +378,7 @@ jobs:
 - name: build-bosh-cli-v2
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -381,6 +395,7 @@ jobs:
 - name: build-awscli
   plan:
   - get: paas-docker-cloudfoundry-tools
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -397,6 +412,7 @@ jobs:
 - name: build-paas-tech-docs
   plan:
   - get: paas-tech-docs
+    trigger: true
   - task: build
     privileged: true
     config:
@@ -419,6 +435,7 @@ jobs:
 - name: build-paas-semver-resource
   plan:
   - get: paas-semver-resource
+    trigger: true
   - task: build
     privileged: true
     config:

--- a/pipelines/plain_pipelines/build-docker-pull-requests.yml
+++ b/pipelines/plain_pipelines/build-docker-pull-requests.yml
@@ -182,9 +182,13 @@ jobs:
           - -u
           - -c
           - |
-            cut -d : -f 2 image/digest > image/sha
-            cd paas-docker-cloudfoundry-tools-pr && git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /' > ../image/branch
-            cat ../image/sha ../image/branch | tr -d '\n' > ../image/tags
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name},${git_commit_sha}" > image/tags
     on_success:
       do:
         - put: psql


### PR DESCRIPTION
What
----

When we replace docker hub builds, and get faster builds, we should keep the behaviour of:

- tagging the image with the branch name (this is already done for PR builds)
- tagging the image with the _git_ commit sha (this is currently not done for either HEAD or PR builds)

We should not keep the current behavior of tagging the image with the image digest, as we can refer to the image by digest without the indirection of a tag: `digest: sha256:123456...etc`

We should also trigger image builds when HEAD changes

How to review
-------------

Code review
