### PR TITLE
[#171281178] Versioning pipeline for paas-prometheus-endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     export PATH=~/bin:$PATH
   - |
     echo "Fetching shellcheck"
-    wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv
+    wget -qO- "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv
     cp "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" ~/bin
   - |
     echo "Fetching Terraform"

--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -61,3 +61,4 @@ setup_test_pipeline aiven-broker alphagov paas-aiven-broker master
 setup_test_pipeline s3-broker alphagov paas-s3-broker master
 setup_test_pipeline paas-service-broker-base alphagov paas-service-broker-base master
 setup_test_pipeline paas-trusted-people alphagov paas-trusted-people master
+setup_test_pipeline paas-prometheus-endpoints alphagov paas-prometheus-endpoints master


### PR DESCRIPTION
What
----

This commit adds an "integration test" pipeline for the new https://github.com/alphagov/paas-prometheus-endpoints repo.

We don't have any integration tests for that repo yet, but in time we may and the pipeline will make version tags in the repo which is useful to pin to in `paas-cf`.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit.