### PR TITLE
[#171281178] paas-prometheus-endpoints default branch is main

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -61,4 +61,4 @@ setup_test_pipeline aiven-broker alphagov paas-aiven-broker master
 setup_test_pipeline s3-broker alphagov paas-s3-broker master
 setup_test_pipeline paas-service-broker-base alphagov paas-service-broker-base master
 setup_test_pipeline paas-trusted-people alphagov paas-trusted-people master
-setup_test_pipeline paas-prometheus-endpoints alphagov paas-prometheus-endpoints master
+setup_test_pipeline paas-prometheus-endpoints alphagov paas-prometheus-endpoints main


### PR DESCRIPTION
What
----

In line with [recent GDS guidance](https://docs.google.com/document/d/1LpBxQ9zJZp7c4eygTMWBQzGNtb9hMh-2SEV3jOlLLxY/edit?ts=5f10079a) we're going to use `main` as the branch name for new repositories.

How to review
-------------

Code review.

Who can review
--------------

Not @46bit