### PR TITLE
Setup additional registry

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -29,7 +29,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/semver-resource
+      repository: ghcr.io/alphagov/paas/semver-resource
       tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
 resources:
@@ -89,8 +89,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/bosh-cli-v2
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: bosh-release-pr
           outputs:
@@ -161,8 +161,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/bosh-cli-v2
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: bosh-release-repo
             - name: bosh-release-version

--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -22,7 +22,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: semver-iam

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -11,7 +11,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/semver-resource
+      repository: ghcr.io/alphagov/paas/semver-resource
       tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
 resources:
@@ -58,8 +58,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/terraform
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/terraform
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-release-ci
             - name: release-ci-tfstate

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -4,7 +4,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: semver-iam

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -12,7 +12,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
 resources:

--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -25,6 +25,7 @@ resources:
 
 - name: psql
   type: registry-image
+  icon: docker
   source: &build-image-source
     username: ((dockerhub_username))
     password: ((dockerhub_password))
@@ -32,90 +33,105 @@ resources:
 
 - name: spruce
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/spruce
 
 - name: json-minify
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/json-minify
 
 - name: terraform
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/terraform
 
 - name: self-update-pipelines
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/self-update-pipelines
 
 - name: git-ssh
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/git-ssh
 
 - name: curl-ssl
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/curl-ssl
 
 - name: cf-cli
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/cf-cli
 
 - name: cf-acceptance-tests
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/cf-acceptance-tests
 
 - name: cf-uaac
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/cf-uaac
 
 - name: certstrap
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/certstrap
 
 - name: bosh-cli-v2
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/bosh-cli-v2
 
 - name: awscli
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/awscli
 
 - name: tech-docs
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/tech-docs
 
 - name: semver-resource
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/semver-resource
 
 - name: grafana-annotation-resource
   type: registry-image
+  icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/grafana-annotation-resource

--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -23,10 +23,10 @@ resources:
     uri: https://github.com/alphagov/paas-grafana-annotation-resource.git
     branch: main
 
-- name: psql
+- name: psql-docker-registry
   type: registry-image
   icon: docker
-  source: &build-image-source
+  source: &build-image-source-docker-registry
     username: ((dockerhub_username))
     password: ((dockerhub_password))
     repository: governmentpaas/psql
@@ -39,11 +39,11 @@ resources:
     password: ((github_registry_access_token))
     repository: ghcr.io/alphagov/paas/psql
 
-- name: spruce
+- name: spruce-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/spruce
 
 - name: spruce-github-registry
@@ -53,11 +53,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/spruce
 
-- name: json-minify
+- name: json-minify-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/json-minify
 
 - name: json-minify-github-registry
@@ -67,11 +67,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/json-minify
 
-- name: terraform
+- name: terraform-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/terraform
 
 - name: terraform-github-registry
@@ -81,11 +81,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/terraform
 
-- name: self-update-pipelines
+- name: self-update-pipelines-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/self-update-pipelines
 
 - name: self-update-pipelines-github-registry
@@ -95,11 +95,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/self-update-pipelines
 
-- name: git-ssh
+- name: git-ssh-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/git-ssh
 
 - name: git-ssh-github-registry
@@ -109,11 +109,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/git-ssh
 
-- name: curl-ssl
+- name: curl-ssl-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/curl-ssl
 
 - name: curl-ssl-github-registry
@@ -123,11 +123,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/curl-ssl
 
-- name: cf-cli
+- name: cf-cli-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/cf-cli
 
 - name: cf-cli-github-registry
@@ -137,11 +137,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/cf-cli
 
-- name: cf-acceptance-tests
+- name: cf-acceptance-tests-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/cf-acceptance-tests
 
 - name: cf-acceptance-tests-github-registry
@@ -151,11 +151,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/cf-acceptance-tests
 
-- name: cf-uaac
+- name: cf-uaac-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/cf-uaac
 
 - name: cf-uaac-github-registry
@@ -165,11 +165,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/cf-uaac
 
-- name: certstrap
+- name: certstrap-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/certstrap
 
 - name: certstrap-github-registry
@@ -179,11 +179,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/certstrap
 
-- name: bosh-cli-v2
+- name: bosh-cli-v2-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/bosh-cli-v2
 
 - name: bosh-cli-v2-github-registry
@@ -193,11 +193,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
 
-- name: awscli
+- name: awscli-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/awscli
 
 - name: awscli-github-registry
@@ -207,11 +207,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/awscli
 
-- name: tech-docs
+- name: tech-docs-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/tech-docs
 
 - name: tech-docs-github-registry
@@ -221,11 +221,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/tech-docs
 
-- name: semver-resource
+- name: semver-resource-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/semver-resource
 
 - name: semver-resource-github-registry
@@ -235,11 +235,11 @@ resources:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/semver-resource
 
-- name: grafana-annotation-resource
+- name: grafana-annotation-resource-docker-registry
   type: registry-image
   icon: docker
   source:
-    <<: *build-image-source
+    <<: *build-image-source-docker-registry
     repository: governmentpaas/grafana-annotation-resource
 
 - name: grafana-annotation-resource-github-registry
@@ -296,7 +296,7 @@ jobs:
                      git log --pretty=format:'%H' -n 1)"
 
             echo "${git_branch_name} ${git_commit_sha}" > image/tags
-  - put: psql
+  - put: psql-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -317,7 +317,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/spruce
   - task: create-image-tag
     config: *create-image-tag
-  - put: spruce
+  - put: spruce-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -338,7 +338,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/json-minify
   - task: create-image-tag
     config: *create-image-tag
-  - put: json-minify
+  - put: json-minify-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -359,7 +359,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/terraform
   - task: create-image-tag
     config: *create-image-tag
-  - put: terraform
+  - put: terraform-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -380,7 +380,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/self-update-pipelines
   - task: create-image-tag
     config: *create-image-tag
-  - put: self-update-pipelines
+  - put: self-update-pipelines-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -401,7 +401,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/git-ssh
   - task: create-image-tag
     config: *create-image-tag
-  - put: git-ssh
+  - put: git-ssh-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -422,7 +422,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/curl-ssl
   - task: create-image-tag
     config: *create-image-tag
-  - put: curl-ssl
+  - put: curl-ssl-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -443,7 +443,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/cf-cli
   - task: create-image-tag
     config: *create-image-tag
-  - put: cf-cli
+  - put: cf-cli-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -464,7 +464,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/cf-acceptance-tests
   - task: create-image-tag
     config: *create-image-tag
-  - put: cf-acceptance-tests
+  - put: cf-acceptance-tests-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -485,7 +485,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/cf-uaac
   - task: create-image-tag
     config: *create-image-tag
-  - put: cf-uaac
+  - put: cf-uaac-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -506,7 +506,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/certstrap
   - task: create-image-tag
     config: *create-image-tag
-  - put: certstrap
+  - put: certstrap-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -527,7 +527,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/bosh-cli-v2
   - task: create-image-tag
     config: *create-image-tag
-  - put: bosh-cli-v2
+  - put: bosh-cli-v2-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -548,7 +548,7 @@ jobs:
         CONTEXT: paas-docker-cloudfoundry-tools/awscli
   - task: create-image-tag
     config: *create-image-tag
-  - put: awscli
+  - put: awscli-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -576,7 +576,7 @@ jobs:
       - name: image
       run:
         path: build
-  - put: tech-docs
+  - put: tech-docs-docker-registry
     params:
       image: image/image.tar
 
@@ -629,7 +629,7 @@ jobs:
                      git log --pretty=format:'%H' -n 1)"
 
             echo "${git_branch_name} ${git_commit_sha}" > image/tags
-  - put: semver-resource
+  - put: semver-resource-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -683,7 +683,7 @@ jobs:
                      git log --pretty=format:'%H' -n 1)"
 
             echo "${git_branch_name} ${git_commit_sha}" > image/tags
-  - put: grafana-annotation-resource
+  - put: grafana-annotation-resource-docker-registry
     params:
       image: image/image.tar
       additional_tags: image/tags

--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -23,6 +23,12 @@ resources:
     uri: https://github.com/alphagov/paas-grafana-annotation-resource.git
     branch: main
 
+- name: s3-resource-src
+  type: git
+  source:
+    uri: https://github.com/alphagov/paas-s3-resource.git
+    branch: gds_master
+
 - name: psql-docker-registry
   type: registry-image
   icon: docker
@@ -248,6 +254,13 @@ resources:
   source:
     <<: *build-image-source-github-registry
     repository: ghcr.io/alphagov/paas/grafana-annotation-resource
+
+- name: s3-resource-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/s3-resource
 
 jobs:
 - name: build-psql
@@ -688,6 +701,56 @@ jobs:
       image: image/image.tar
       additional_tags: image/tags
   - put: grafana-annotation-resource-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-s3-resource
+  plan:
+  - get: s3-resource-src
+    trigger: true
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: s3-resource-src
+        path: .
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: s3-resource-src
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd s3-resource-src && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd s3-resource-src && \
+                      git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: s3-resource-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags

--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -31,12 +31,27 @@ resources:
     password: ((dockerhub_password))
     repository: governmentpaas/psql
 
+- name: psql-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/psql
+
 - name: spruce
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/spruce
+
+- name: spruce-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/spruce
 
 - name: json-minify
   type: registry-image
@@ -45,12 +60,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/json-minify
 
+- name: json-minify-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/json-minify
+
 - name: terraform
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/terraform
+
+- name: terraform-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/terraform
 
 - name: self-update-pipelines
   type: registry-image
@@ -59,12 +88,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/self-update-pipelines
 
+- name: self-update-pipelines-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/self-update-pipelines
+
 - name: git-ssh
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/git-ssh
+
+- name: git-ssh-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/git-ssh
 
 - name: curl-ssl
   type: registry-image
@@ -73,12 +116,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/curl-ssl
 
+- name: curl-ssl-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/curl-ssl
+
 - name: cf-cli
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/cf-cli
+
+- name: cf-cli-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/cf-cli
 
 - name: cf-acceptance-tests
   type: registry-image
@@ -87,12 +144,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/cf-acceptance-tests
 
+- name: cf-acceptance-tests-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/cf-acceptance-tests
+
 - name: cf-uaac
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/cf-uaac
+
+- name: cf-uaac-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/cf-uaac
 
 - name: certstrap
   type: registry-image
@@ -101,12 +172,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/certstrap
 
+- name: certstrap-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/certstrap
+
 - name: bosh-cli-v2
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/bosh-cli-v2
+
+- name: bosh-cli-v2-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/bosh-cli-v2
 
 - name: awscli
   type: registry-image
@@ -115,12 +200,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/awscli
 
+- name: awscli-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/awscli
+
 - name: tech-docs
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/tech-docs
+
+- name: tech-docs-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/tech-docs
 
 - name: semver-resource
   type: registry-image
@@ -129,12 +228,26 @@ resources:
     <<: *build-image-source
     repository: governmentpaas/semver-resource
 
+- name: semver-resource-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/semver-resource
+
 - name: grafana-annotation-resource
   type: registry-image
   icon: docker
   source:
     <<: *build-image-source
     repository: governmentpaas/grafana-annotation-resource
+
+- name: grafana-annotation-resource-github-registry
+  type: registry-image
+  icon: github
+  source:
+    <<: *build-image-source-github-registry
+    repository: ghcr.io/alphagov/paas/grafana-annotation-resource
 
 jobs:
 - name: build-psql
@@ -187,6 +300,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: psql-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-spruce
   plan:
@@ -201,6 +318,10 @@ jobs:
   - task: create-image-tag
     config: *create-image-tag
   - put: spruce
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: spruce-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -221,6 +342,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: json-minify-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-terraform
   plan:
@@ -235,6 +360,10 @@ jobs:
   - task: create-image-tag
     config: *create-image-tag
   - put: terraform
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: terraform-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -255,6 +384,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: self-update-pipelines-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-git-ssh
   plan:
@@ -269,6 +402,10 @@ jobs:
   - task: create-image-tag
     config: *create-image-tag
   - put: git-ssh
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: git-ssh-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -289,6 +426,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: curl-ssl-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-cf-cli
   plan:
@@ -303,6 +444,10 @@ jobs:
   - task: create-image-tag
     config: *create-image-tag
   - put: cf-cli
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: cf-cli-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -323,6 +468,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: cf-acceptance-tests-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-cf-uaac
   plan:
@@ -337,6 +486,10 @@ jobs:
   - task: create-image-tag
     config: *create-image-tag
   - put: cf-uaac
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: cf-uaac-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -357,6 +510,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: certstrap-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-bosh-cli-v2
   plan:
@@ -374,6 +531,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: bosh-cli-v2-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-awscli
   plan:
@@ -388,6 +549,10 @@ jobs:
   - task: create-image-tag
     config: *create-image-tag
   - put: awscli
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: awscli-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags
@@ -412,6 +577,10 @@ jobs:
       run:
         path: build
   - put: tech-docs
+    params:
+      image: image/image.tar
+
+  - put: tech-docs-github-registry
     params:
       image: image/image.tar
 
@@ -464,6 +633,10 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: image/tags
+  - put: semver-resource-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
 
 - name: build-paas-grafana-annotation-resource
   plan:
@@ -511,6 +684,10 @@ jobs:
 
             echo "${git_branch_name} ${git_commit_sha}" > image/tags
   - put: grafana-annotation-resource
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: grafana-annotation-resource-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -65,8 +65,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/cf-cli
-              tag: latest
+              repository: ghcr.io/alphagov/paas/cf-cli
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-codimd
           params:

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -4,7 +4,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: slack-notification-resource

--- a/pipelines/plain_pipelines/paas-product-pages.yml
+++ b/pipelines/plain_pipelines/paas-product-pages.yml
@@ -60,8 +60,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/cf-cli
-              tag: b9a032b6ca185690bd679e1802e6b7af6a2bc43a
+              repository: ghcr.io/alphagov/paas/cf-cli
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-product-pages
           params:

--- a/pipelines/plain_pipelines/paas-team-manual.yml
+++ b/pipelines/plain_pipelines/paas-team-manual.yml
@@ -5,7 +5,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: slack-notification-resource

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -5,7 +5,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: slack-notification-resource

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -37,7 +37,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/tech-docs
+              repository: ghcr.io/alphagov/paas/tech-docs
               tag: latest
           inputs:
             - name: paas-tech-docs
@@ -68,7 +68,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/tech-docs
+              repository: ghcr.io/alphagov/paas/tech-docs
               tag: latest
           inputs:
             - name: paas-tech-docs
@@ -97,8 +97,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/cf-cli
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              repository: ghcr.io/alphagov/paas/cf-cli
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: files-to-push
           params:

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -68,8 +68,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/cf-cli
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              repository: ghcr.io/alphagov/paas/cf-cli
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-rubbernecker
           params:

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -4,7 +4,7 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: slack-notification-resource

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -3,7 +3,7 @@ resource_types:
   - name: s3-iam
     type: docker-image
     source:
-      repository: governmentpaas/s3-resource
+      repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: semver-iam

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -9,7 +9,7 @@ resource_types:
   - name: semver-iam
     type: docker-image
     source:
-      repository: governmentpaas/semver-resource
+      repository: ghcr.io/alphagov/paas/semver-resource
       tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
   - name: slack-notification-resource
@@ -91,8 +91,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/self-update-pipelines
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/self-update-pipelines
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-release-ci
           params:
@@ -147,8 +147,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/terraform
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/terraform
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-release-ci
             - name: release-ci-tfstate
@@ -192,8 +192,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/git-ssh
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/git-ssh
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: ssh-private-key
             - name: ssh-public-key
@@ -246,8 +246,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/self-update-pipelines
-              tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+              repository: ghcr.io/alphagov/paas/self-update-pipelines
+              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
           inputs:
             - name: paas-release-ci
           params:

--- a/scripts/upload-secrets/upload-github-secrets.rb
+++ b/scripts/upload-secrets/upload-github-secrets.rb
@@ -4,12 +4,24 @@
 require_relative "./upload-secrets.rb"
 
 github_access_token = ENV["GITHUB_ACCESS_TOKEN"] || `pass github.com/release_ci_pr_status_token`
+github_username = ENV["GITHUB_USERNAME"] || `pass github.com/ci-user-username`
+github_registry_access_token = ENV["GITHUB_REGISTRY_ACCESS_TOKEN"] || `pass github.com/ci-user-container-registry-token`
 
 secrets = [
   {
     "name" => "/concourse/main/github_access_token",
     "type" => "value",
     "value" => github_access_token.chomp
+  },
+  {
+    "name" => "/concourse/main/github_username",
+    "type" => "value",
+    "value" => github_username.chomp
+  },
+  {
+    "name" => "/concourse/main/github_registry_access_token",
+    "type" => "value",
+    "value" => github_registry_access_token.chomp
   },
 ]
 


### PR DESCRIPTION
What
----

We no longer want to fully rely on docker, due to the changes they've made to their rate limiting and image retention.

We're adding an additional registry in the shape of GitHub Container Registry. Along with that, we need authentication method sorted.

Also, some visual aids have been added into the mix to make my life easier.

How to review
-------------

- Commit by Commit code review recommended
- Push secrets `make ci credhub && make ci upload-github-secrets`
- Set pipelines `make ci plain-pipelines`
- See jobs running in CI concourse
