### PR TITLE
Switch `cf push zdt` for `cf push --strategy rolling`

### DIFF
--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -151,6 +151,6 @@ jobs:
                     REDIRECT_DOMAIN: "docs.${CF_SYSTEM_DOMAIN}"
                 EOF
 
-                cf zero-downtime-push paas-tech-docs -f manifest.yml
-                cf zero-downtime-push paas-tech-docs-redirect -f manifest.yml
+                cf push paas-tech-docs -f manifest.yml --strategy rolling
+                cf push paas-tech-docs-redirect -f manifest.yml --strategy rolling
         on_failure: *slack_failure_notification

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -118,5 +118,5 @@ jobs:
                     GOVERSION: go1.14
                 EOF
 
-                cf zero-downtime-push rubbernecker -f manifest.yml
+                cf push rubbernecker -f manifest.yml --strategy rolling
         on_failure: *slack_failure_notification


### PR DESCRIPTION
What
----

Switch `cf push zdt` for `cf push --strategy rolling`

We are now using cf cli v7 where `--strategy rolling` is built in. we no
longer install the zero-downtime plugin in the container, [which causes failures](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-tech-docs/jobs/deploy/builds/63)


How to review
-------------

Code review

Who can review
--------------

Anyone
