### PR TITLE
[#176226306] Build docker images that mirror DockerHub

### DIFF
--- a/pipelines/plain_pipelines/build-docker-containers.yml
+++ b/pipelines/plain_pipelines/build-docker-containers.yml
@@ -51,6 +51,102 @@ resources:
     password: ((github_registry_access_token))
     repository: ghcr.io/alphagov/paas/psql
 
+- name: alpine-docker-registry
+  type: registry-image
+  icon: docker
+  source: &build-image-source-docker-registry
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/alpine
+
+- name: alpine-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/alpine
+
+- name: golang-docker-registry
+  type: registry-image
+  icon: docker
+  source: &build-image-source-docker-registry
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/golang
+
+- name: golang-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/golang
+
+- name: node-docker-registry
+  type: registry-image
+  icon: docker
+  source: &build-image-source-docker-registry
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/node
+
+- name: node-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/node
+
+- name: olhtbr-metadata-resource-docker-registry
+  type: registry-image
+  icon: docker
+  source: &build-image-source-docker-registry
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/olhtbr-metadata-resource
+
+- name: olhtbr-metadata-resource-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/olhtbr-metadata-resource
+
+- name: concourse-pool-resource-docker-registry
+  type: registry-image
+  icon: docker
+  source: &build-image-source-docker-registry
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/concourse-pool-resource
+
+- name: concourse-pool-resource-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/concourse-pool-resource
+
+- name: ruby-docker-registry
+  type: registry-image
+  icon: docker
+  source: &build-image-source-docker-registry
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/ruby
+
+- name: ruby-github-registry
+  type: registry-image
+  icon: github
+  source: &build-image-source-github-registry
+    username: ((github_username))
+    password: ((github_registry_access_token))
+    repository: ghcr.io/alphagov/paas/ruby
+
 - name: spruce-docker-registry
   type: registry-image
   icon: docker
@@ -376,6 +472,336 @@ jobs:
       image: image/image.tar
       additional_tags: image/tags
   - put: json-minify-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-alpine
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+    trigger: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/alpine
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: alpine-docker-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: alpine-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-golang
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+    trigger: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/golang
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: golang-docker-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: golang-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-node
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+    trigger: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/node
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: node-docker-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: node-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-olhtbr-metadata-resource
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+    trigger: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/olhtbr-metadata-resource
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: olhtbr-metadata-resource-docker-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: olhtbr-metadata-resource-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-concourse-pool-resource
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+    trigger: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/concourse-pool-resource
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: concourse-pool-resource-docker-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: concourse-pool-resource-github-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+
+- name: build-ruby
+  plan:
+  - get: paas-docker-cloudfoundry-tools
+    trigger: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools/ruby
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+  - put: ruby-docker-registry
+    params:
+      image: image/image.tar
+      additional_tags: image/tags
+  - put: ruby-github-registry
     params:
       image: image/image.tar
       additional_tags: image/tags

--- a/pipelines/plain_pipelines/build-docker-pull-requests.yml
+++ b/pipelines/plain_pipelines/build-docker-pull-requests.yml
@@ -48,6 +48,54 @@ resources:
     repository: governmentpaas/psql
     tag: pr-build
 
+- name: alpine
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/alpine
+    tag: pr-build
+
+- name: golang
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/golang
+    tag: pr-build
+
+- name: node
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/node
+    tag: pr-build
+
+- name: olhtbr-metadata-resource
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/olhtbr-metadata-resource
+    tag: pr-build
+
+- name: concourse-pool-resource
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/concourse-pool-resource
+    tag: pr-build
+
+- name: ruby
+  type: registry-image
+  source: &build-image-source
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+    repository: governmentpaas/ruby
+    tag: pr-build
+
 - name: spruce
   type: registry-image
   source:
@@ -216,6 +264,492 @@ jobs:
       params:
         path: paas-docker-cloudfoundry-tools-pr
         context: ((github_status_context))/build-psql-pr
+        status: FAILURE
+      get_params:
+        skip_download: true
+
+- name: build-alpine-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+    params:
+      integration_tool: checkout
+      submodules: true
+  - put: update-paas-docker-cloudfoundry-tools-pr
+    resource: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))/build-alpine-pr
+      status: PENDING
+    get_params:
+      skip_download: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/alpine
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+    on_success:
+      do:
+        - put: alpine
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))/build-alpine-pr
+            status: SUCCESS
+          get_params:
+            skip_download: true
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))/build-alpine-pr
+        status: FAILURE
+      get_params:
+        skip_download: true
+
+- name: build-golang-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+    params:
+      integration_tool: checkout
+      submodules: true
+  - put: update-paas-docker-cloudfoundry-tools-pr
+    resource: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))/build-golang-pr
+      status: PENDING
+    get_params:
+      skip_download: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/golang
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+    on_success:
+      do:
+        - put: golang
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))/build-golang-pr
+            status: SUCCESS
+          get_params:
+            skip_download: true
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))/build-golang-pr
+        status: FAILURE
+      get_params:
+        skip_download: true
+
+- name: build-node-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+    params:
+      integration_tool: checkout
+      submodules: true
+  - put: update-paas-docker-cloudfoundry-tools-pr
+    resource: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))/build-node-pr
+      status: PENDING
+    get_params:
+      skip_download: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/node
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+    on_success:
+      do:
+        - put: node
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))/build-node-pr
+            status: SUCCESS
+          get_params:
+            skip_download: true
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))/build-node-pr
+        status: FAILURE
+      get_params:
+        skip_download: true
+
+- name: build-olhtbr-metadata-resource-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+    params:
+      integration_tool: checkout
+      submodules: true
+  - put: update-paas-docker-cloudfoundry-tools-pr
+    resource: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))/build-olhtbr-metadata-resource-pr
+      status: PENDING
+    get_params:
+      skip_download: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/olhtbr-metadata-resource
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+    on_success:
+      do:
+        - put: olhtbr-metadata-resource
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))/build-olhtbr-metadata-resource-pr
+            status: SUCCESS
+          get_params:
+            skip_download: true
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))/build-olhtbr-metadata-resource-pr
+        status: FAILURE
+      get_params:
+        skip_download: true
+
+- name: build-concourse-pool-resource-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+    params:
+      integration_tool: checkout
+      submodules: true
+  - put: update-paas-docker-cloudfoundry-tools-pr
+    resource: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))/build-concourse-pool-resource-pr
+      status: PENDING
+    get_params:
+      skip_download: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/concourse-pool-resource
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+    on_success:
+      do:
+        - put: concourse-pool-resource
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))/build-concourse-pool-resource-pr
+            status: SUCCESS
+          get_params:
+            skip_download: true
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))/build-concourse-pool-resource-pr
+        status: FAILURE
+      get_params:
+        skip_download: true
+
+- name: build-ruby-pr
+  serial: true
+  plan:
+  - get: paas-docker-cloudfoundry-tools-pr
+    version: every
+    trigger: true
+    params:
+      integration_tool: checkout
+      submodules: true
+  - put: update-paas-docker-cloudfoundry-tools-pr
+    resource: paas-docker-cloudfoundry-tools-pr
+    params:
+      path: paas-docker-cloudfoundry-tools-pr
+      context: ((github_status_context))/build-ruby-pr
+      status: PENDING
+    get_params:
+      skip_download: true
+  - task: build
+    privileged: true
+    config: &build-image-config
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        CONTEXT: paas-docker-cloudfoundry-tools-pr/ruby
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      outputs:
+      - name: image
+      run:
+        path: build
+  - task: create-image-tag
+    config: &create-image-tag
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: paas-docker-cloudfoundry-tools-pr
+      - name: image
+      outputs:
+      - name: image
+      run:
+        path: sh
+        args:
+          - -e
+          - -u
+          - -c
+          - |
+            git_branch_name="$(cd paas-docker-cloudfoundry-tools-pr && \
+                          git rev-parse --abbrev-ref HEAD | sed -e 's/^/ /')"
+
+            git_commit_sha="$(cd paas-docker-cloudfoundry-tools-pr && \
+                     git log --pretty=format:'%H' -n 1)"
+
+            echo "${git_branch_name} ${git_commit_sha}" > image/tags
+    on_success:
+      do:
+        - put: ruby
+          params:
+            image: image/image.tar
+            additional_tags: image/tags
+        - put: paas-docker-cloudfoundry-tools-pr
+          params:
+            path: paas-docker-cloudfoundry-tools-pr
+            context: ((github_status_context))/build-ruby-pr
+            status: SUCCESS
+          get_params:
+            skip_download: true
+    on_failure:
+      put: paas-docker-cloudfoundry-tools-pr
+      params:
+        path: paas-docker-cloudfoundry-tools-pr
+        context: ((github_status_context))/build-ruby-pr
         status: FAILURE
       get_params:
         skip_download: true


### PR DESCRIPTION
## What

DockerHub recently started rate limiting image pulls. We aren't giving credentials to all production pipelines, and so our effective rate limit is quite low.

We are stopping relying on DockerHub for production CI/CD pipelines. Instead we're going to rely on GitHub Container Registry (GHCR.)

Most of our images are already being mirrored onto GHCR when they are built [1]. But we have also used some third-party DockerHub images that don't have copies on GHCR.

This commit adds tiny Dockerfiles that merely re-export those third-party images. The advantage of doing this, vs a `docker pull` and `docker push`, is that we can fit into the existing patterns of image building and CI setup.

[1] https://github.com/alphagov/paas-release-ci/blob/master/pipelines/plain_pipelines/build-docker-containers.yml

## How to review

Easiest to review https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/207 first, and then test this PR once that is merged.