### PR TITLE
Rather than just doing `*` select `*.yml`

### DIFF
--- a/scripts/plain-pipelines.sh
+++ b/scripts/plain-pipelines.sh
@@ -23,7 +23,7 @@ EOF
 echo -e "tagging_key: |\n  ${SSH_KEY//$'\n'/$'\n'  }"
 }
 
-for pipeline_path in "${SCRIPTS_DIR}"/../pipelines/plain_pipelines/* ; do
+for pipeline_path in "${SCRIPTS_DIR}"/../pipelines/plain_pipelines/*.yml ; do
   (
     pipeline_name=${pipeline_path##*/}
     pipeline_name=${pipeline_name%%.yml}


### PR DESCRIPTION
What
----

glob *.yml files, not just *

This allows 'x.yml.bak / x.yml.disabled' which will not be deployed

How to review
-------------

* Code review
* `touch pipelines/plain_pipelines/*.yml.not_a_yml`
* `ls pipelines/plain_pipelines/*.yml`

Who can review
--------------

Not @me
