### PR TITLE
Correctly clone submodules in git Concourse resources

### DIFF
--- a/pipelines/plain_pipelines/paas-rds-broker.yml
+++ b/pipelines/plain_pipelines/paas-rds-broker.yml
@@ -77,7 +77,7 @@ jobs:
         trigger: true
         params:
           integration_tool: checkout
-          submodules: all
+          submodules: true
 
       # Set the GitHub check status to "PENDING"
       - put: update-repo
@@ -113,7 +113,7 @@ jobs:
         passed: [integration-test]
         params:
           integration_tool: checkout
-          submodules: all
+          submodules: true
 
       # Create a bosh release from it
       - task: build-dev-release
@@ -178,7 +178,7 @@ jobs:
         trigger: true
         params:
           integration_tool: checkout
-          submodules: all
+          submodules: true
 
       # Get the latest version of the Bosh release
       # and increment the minor version
@@ -243,7 +243,7 @@ jobs:
         trigger: true
         params:
           integration_tool: checkout
-          submodules: all
+          submodules: true
 
       # Run integration tests
       - task: run-tests


### PR DESCRIPTION
What
----

Commit b99c6e3ec9ca35d5ec452d638644799cbe2ec080 is wrong. It's `submodules: true`.

I don't really know how I came to the conclusion that `submodules: all` was correct. It's just not.

How to review
-------------
1. Code review
2. See that it's working in this run: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-rds-broker/jobs/integration-test/builds/19 

Who can review
--------------
Anyone