### PR TITLE
Use the right parameter value for cloning Git resource submodules

### DIFF
--- a/pipelines/plain_pipelines/paas-rds-broker.yml
+++ b/pipelines/plain_pipelines/paas-rds-broker.yml
@@ -178,7 +178,7 @@ jobs:
         trigger: true
         params:
           integration_tool: checkout
-          submodules: true
+          submodules: all
 
       # Get the latest version of the Bosh release
       # and increment the minor version
@@ -243,7 +243,7 @@ jobs:
         trigger: true
         params:
           integration_tool: checkout
-          submodules: true
+          submodules: all
 
       # Run integration tests
       - task: run-tests


### PR DESCRIPTION
What
----

Use the right parameter value for cloning Git resource submodules

Rather confusingly, the parameter value to enable cloning submodules is
different when using a PR resource versus a git repo resource.

For a PR: `submodules: true`
For a repo: `submodules: all`


How to review
-------------
1. [I pushed it to the CI env and it's working](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/paas-rds-broker/jobs/build-prod-release/builds/65)

Who can review
--------------
Me