### PR TITLE
Switch teliaoss-github-pr-resource to ghcr

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -15,7 +15,7 @@ resource_types:
     check_every: 24h
     source:
       # temporary until there is a version which contains the submodule param
-      repository: governmentpaas/teliaoss-github-pr-resource
+      repository: ghcr.io/alphagov/paas/teliaoss-github-pr-resource
       tag: c41729d09b4da671765979933fd7e24388c34e05
 
   - name: s3-iam

--- a/pipelines/integration-test.yml
+++ b/pipelines/integration-test.yml
@@ -5,7 +5,7 @@ resource_types:
     check_every: 24h
     source:
       # temporary until there is a version which contains the submodule param
-      repository: governmentpaas/teliaoss-github-pr-resource
+      repository: ghcr.io/alphagov/paas/teliaoss-github-pr-resource
       tag: c41729d09b4da671765979933fd7e24388c34e05
 
   - name: s3-iam

--- a/pipelines/plain_pipelines/build-docker-pull-requests.yml
+++ b/pipelines/plain_pipelines/build-docker-pull-requests.yml
@@ -4,7 +4,7 @@ resource_types:
     check_every: 24h
     source:
       # temporary until there is a version which contains the submodule param
-      repository: governmentpaas/teliaoss-github-pr-resource
+      repository: ghcr.io/alphagov/paas/teliaoss-github-pr-resource
       tag: c41729d09b4da671765979933fd7e24388c34e05
 
 resources:

--- a/pipelines/plain_pipelines/paas-rds-broker.yml
+++ b/pipelines/plain_pipelines/paas-rds-broker.yml
@@ -5,7 +5,7 @@ resource_types:
     check_every: 24h
     source:
       # temporary until there is a version which contains the submodule param
-      repository: governmentpaas/teliaoss-github-pr-resource
+      repository: ghcr.io/alphagov/paas/teliaoss-github-pr-resource
       tag: c41729d09b4da671765979933fd7e24388c34e05
 
   - name: s3-iam


### PR DESCRIPTION
What
----

This was the last docker registry container we had in use in CI. it has
now been pushed to ghcr.io/alphagov/paas/teliaoss-github-pr-resource so
it made sense to update the pipeline.

How to review
-------------

code review and check you can pull the image

Who can review
--------------

Anyone
