### PR TITLE
Update tech-docs deploy manifest

### DIFF
--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -132,8 +132,6 @@ jobs:
                 applications:
                 - name: paas-tech-docs
                   memory: 64M
-                  path: build
-                  buildpack: staticfile_buildpack
                   instances: 2
                   stack: cflinuxfs3
                   routes:


### PR DESCRIPTION
What
----

Remove `path` and `buildpack` attributes

In https://github.com/alphagov/paas-tech-docs/pull/383 we're adding a `Staticfile` to define error page templates.

There appears to be a bug where if the manifest file contains the path and buildpack attributes and the repo contains a Staticfile, any setting in the Staticfile doesn't get applied.

How to review
-------------

- you can test this by deploying https://github.com/alphagov/paas-tech-docs/pull/383 with the original and modified manifest file and check which one serve the correct error page as defined in the Staticfile.

Who can review
--------------

not @kr8n3r 
