### PR TITLE
paas-rds-broker pipeline: give integration tests add rds-calls-throttled serial_group

### DIFF
--- a/pipelines/plain_pipelines/paas-rds-broker.yml
+++ b/pipelines/plain_pipelines/paas-rds-broker.yml
@@ -69,6 +69,7 @@ resources:
 jobs:
   - name: integration-test
     serial: true
+    serial_groups: [ rds-calls-throttled ]
     plan:
       # Grab the PR content
       - get: repo
@@ -236,6 +237,7 @@ jobs:
             file: bosh-release-version/number
 
   - name: run-prod-integration-tests
+    serial_groups: [ rds-calls-throttled ]
     plan:
       # Get the repo content on `main`
       - get: repo


### PR DESCRIPTION
What
----

AWS applies an account-wide throttle to RDS api calls, which will lead to failures if the RDS broker's integration tests run twice simultaneously.

Use concourse's `serial_groups` feature to prevent this from happening. Hopefully choosing a name for the group which explains its purpose well enough.

How to review
-------------

Look at it and be happy.

Who can review
--------------

Anyone other than @risicle 