### PR TITLE
Run Rubbernecker tests under Go 1.18

### DIFF
--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -38,7 +38,7 @@ jobs:
             type: docker-image
             source:
               repository: golang
-              tag: 1.12
+              tag: 1.18
           inputs:
             - name: paas-rubbernecker
           run:


### PR DESCRIPTION
What
----

It was using a very outdated Go 1.12 image, which had an out-of-date root cert bundle. That prevented it from downloading it's dependencies. 

How to review
-------------
```
$ docker run -it -v "$(pwd):/paas-rubbernecker" golang:1.18 /bin/bash
$ cd /paas-rubbernecker
$ make test
```
