### PR TITLE
rubbernecker: use golang 1.18 for deployment

### DIFF
--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -115,7 +115,7 @@ jobs:
                     PAGERDUTY_AUTHTOKEN: "${PAGERDUTY_AUTHTOKEN}"
                     GO111MODULE: on
                     GOPACKAGENAME: github.com/alphagov/paas-rubbernecker
-                    GOVERSION: go1.16
+                    GOVERSION: go1.18
                 EOF
 
                 cf push rubbernecker -f manifest.yml --strategy rolling


### PR DESCRIPTION
What
----

In https://github.com/alphagov/paas-rubbernecker/pull/80 we updated rubbernecker to require golang 1.18. It won't deploy with `GOLANG` set to 1.16

How to review
-------------

:eyes: 
