### PR TITLE
181929453 - Clean up Go 1.18 bits

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -34,8 +34,7 @@ jobs:
 
       - name: "Install Pipecleaner"
         run: |
-          go get -u github.com/alphagov/paas-cf/tools/pipecleaner
-          go install github.com/alphagov/paas-cf/tools/pipecleaner
+          go install github.com/alphagov/paas-cf/tools/pipecleaner@main
 
       - name: Install Python packages
         run: pip install --user yamllint


### PR DESCRIPTION
Description:
- go get isn't used to install but only to update so pin to main branch to always install the latest pipecleaner

What
----

Describe what you have changed and why.

How to review
-------------

Describe the steps required to test the changes.

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
