### PR TITLE
Stop creating `rds-broker` pipeline

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -9,8 +9,8 @@ $("${SCRIPTS_DIR}/environment.sh")
 "${SCRIPTS_DIR}/fly_sync_and_login.sh"
 
 generate_vars_file() {
-SSH_KEY=$(aws s3 cp s3://"${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}"/ci_build_tag_key -)
-  cat << EOF
+  SSH_KEY=$(aws s3 cp s3://"${STATE_BUCKET_NAME:-gds-paas-${DEPLOY_ENV}-state}"/ci_build_tag_key -)
+  cat <<EOF
 ---
 pipeline_name: ${pipeline_name}
 github_status_context: ${DEPLOY_ENV}/status
@@ -24,7 +24,7 @@ github_repo_uri: git@github.com:${organisation}/${repository}.git
 tag_branch: ${tag_branch}
 version_file: ${version_file}
 EOF
-echo -e "tagging_key: |\n  ${SSH_KEY//$'\n'/$'\n'  }"
+  echo -e "tagging_key: |\n  ${SSH_KEY//$'\n'/$'\n'  }"
 }
 
 setup_test_pipeline() {
@@ -34,7 +34,7 @@ setup_test_pipeline() {
   repository="$3"
   tag_branch="$4"
 
-  generate_vars_file > /dev/null # Check for missing vars
+  generate_vars_file >/dev/null # Check for missing vars
 
   bash "${SCRIPTS_DIR}/deploy-pipeline.sh" \
     "${pipeline_name}" \
@@ -48,8 +48,6 @@ remove_test_pipeline() {
   ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" --non-interactive || true
 }
 
-
-setup_test_pipeline rds-broker alphagov paas-rds-broker main
 setup_test_pipeline paas-billing alphagov paas-billing main
 setup_test_pipeline elasticache-broker alphagov paas-elasticache-broker main
 setup_test_pipeline paas-accounts alphagov paas-accounts main


### PR DESCRIPTION
## What

`rds-broker` was replaced by `paas-rds-broker` in #164

Also, my IDE decided that this file needs to be formatted. I agree with it's assertion.

The meaningful part of this change is: [scripts/integration-test-pipelines.shL52](https://github.com/alphagov/paas-release-ci/pull/199/files#diff-2ef83e3114899c24cca0653d2e2facc53e085bb73a08c8cfacad31be18fa5939L52)

## How to review

Code review

## Who can review

Not Me
