### PR TITLE
Replace `npm bin` with `npx` in product-pages pipeline

### DIFF
--- a/pipelines/plain_pipelines/paas-product-pages.yml
+++ b/pipelines/plain_pipelines/paas-product-pages.yml
@@ -52,7 +52,7 @@ jobs:
               - -c
               - |
                 npm install
-                node "$(npm bin)/rollup" -c && node "$(npm bin)/next" build && node "$(npm bin)/next" export
+                npx rollup -c && npx next build && npx next export
 
       - task: push
         config:


### PR DESCRIPTION
What
----

LTS docker image was updated to Node 18.14.0. - https://hub.docker.com/layers/library/node/lts/images/sha256-f27e3f4c8b5719cb9816084475d687a283c59149f3d11a7aa45b675fea56bed0?context=explore

Node 18.14.0 contains npm cli version 9.3.1 - https://github.com/nodejs/node/commit/66ab03d03240ab11cd415b487314c7cbcc74d7f1

Npm cli versions 9 and never no longer contain the `npm bin` command - https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/#%E2%9A%A0%EF%B8%8F-notable-breaking-changes

Their recommendation is to replace it with `npx`

How to review
--------------

- someway to get Ci to use this branch ? 

Who can review
--------------

not @kr8n3r 
