### PR TITLE
Buildpack changes to tech docs

### DIFF
--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -131,6 +131,7 @@ jobs:
                 ---
                 applications:
                 - name: paas-tech-docs
+                  buildpack: staticfile_buildpack
                   memory: 64M
                   instances: 2
                   stack: cflinuxfs3
@@ -138,7 +139,7 @@ jobs:
                   - route: "docs.${CF_SYSTEM_DOMAIN}"
 
                 - name: paas-tech-docs-redirect
-                  buildpack: staticfile_buildpack
+                  buildpack: nginx_buildpack
                   path: redirect
                   memory: 32M
                   instances: 2


### PR DESCRIPTION
What
----

Switch the buildpack we use for the tech docs redirect deployment.

Set the buildpack to staticfile_buildpack for the tech docs main site.

How to review
-------------

Look at the change.

Who can review
--------------

Any team member.
