### PR TITLE
Switch back to the OG github-pr-resource at v0.23.0

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -14,9 +14,8 @@ resource_types:
     type: docker-image
     check_every: 24h
     source:
-      # temporary until there is a version which contains the submodule param
-      repository: ghcr.io/alphagov/paas/teliaoss-github-pr-resource
-      tag: c41729d09b4da671765979933fd7e24388c34e05
+      repository: teliaoss/github-pr-resource
+      tag: v0.23.0
 
   - name: s3-iam
     type: docker-image


### PR DESCRIPTION
What
----

Previously we were using a forked version of this resource because we needed a `submodules` param that wasn't yet released. This param is now released and it's less maintenance to not use our fork.

How to review
-------------

Deploy this branch to the build pipeline and check that PR resources are still working.

Who can review
--------------

Anyone.