### PR TITLE
pipelines: update docker images

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,7 +1,7 @@
 on: pull_request
 
 env:
-  TF_VERSION: "1.0.8"
+  TF_VERSION: "1.5.2"
   SHELLCHECK_VERSION: "0.7.1"
   GO_VERSION: "1.18"
 

--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -11,21 +11,21 @@ groups:
 
 resource_types:
   - name: pull-request
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: teliaoss/github-pr-resource
       tag: v0.23.0
 
   - name: s3-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: semver-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/semver-resource
@@ -86,10 +86,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: bosh-release-pr
           outputs:
@@ -158,10 +158,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: bosh-release-repo
             - name: bosh-release-version

--- a/pipelines/destroy.yml
+++ b/pipelines/destroy.yml
@@ -1,14 +1,14 @@
 ---
 resource_types:
   - name: s3-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: semver-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/semver-resource
@@ -56,10 +56,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-release-ci
             - name: release-ci-tfstate
@@ -77,10 +77,11 @@ jobs:
               - -c
               - |
                 cp release-ci-tfstate/release-ci.tfstate updated-release-ci-tfstate/release-ci.tfstate
-                terraform init paas-release-ci/terraform
+
+                cd paas-release-ci/terraform || exit
+                terraform init
                 terraform destroy -force \
-                  -state=updated-release-ci-tfstate/release-ci.tfstate \
-                  paas-release-ci/terraform
+                  -state="../../updated-release-ci-tfstate/release-ci.tfstate"
         ensure:
           put: release-ci-tfstate
           params:

--- a/pipelines/plain_pipelines/paas-hackmd.yml
+++ b/pipelines/plain_pipelines/paas-hackmd.yml
@@ -1,14 +1,14 @@
 ---
 resource_types:
   - name: s3-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/s3-resource
       tag: fda60bf4c5f85e96c16f704e128e5ead9e84d30d
 
   - name: slack-notification-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
 
@@ -36,7 +36,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: node
               tag: 10
@@ -63,10 +63,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-codimd
           params:

--- a/pipelines/plain_pipelines/paas-nginx-hosts-reload.yml
+++ b/pipelines/plain_pipelines/paas-nginx-hosts-reload.yml
@@ -72,10 +72,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: pr
           outputs:
@@ -143,10 +143,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: repo
             - name: bosh-release-version

--- a/pipelines/plain_pipelines/paas-product-pages.yml
+++ b/pipelines/plain_pipelines/paas-product-pages.yml
@@ -1,7 +1,7 @@
 ---
 resource_types:
   - name: slack-notification-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
 
@@ -35,7 +35,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: node
               tag: lts
@@ -58,10 +58,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-product-pages
           params:

--- a/pipelines/plain_pipelines/paas-rds-broker.yml
+++ b/pipelines/plain_pipelines/paas-rds-broker.yml
@@ -1,7 +1,7 @@
 ---
 resource_types:
   - name: pull-request
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       # temporary until there is a version which contains the submodule param
@@ -9,19 +9,19 @@ resource_types:
       tag: c41729d09b4da671765979933fd7e24388c34e05
 
   - name: s3-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: slack-notification-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
 
   - name: semver-iam
-    type: docker-image
+    type: registry-image
     check_every: 24h
     source:
       repository: ghcr.io/alphagov/paas/semver-resource
@@ -121,10 +121,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: pr
           outputs:
@@ -192,10 +192,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/bosh-cli-v2
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: repo
             - name: bosh-release-version

--- a/pipelines/plain_pipelines/paas-tech-docs.yml
+++ b/pipelines/plain_pipelines/paas-tech-docs.yml
@@ -98,7 +98,7 @@ jobs:
             type: docker-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: files-to-push
           params:

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -66,10 +66,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/cf-cli
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-rubbernecker
           params:

--- a/pipelines/setup.yml
+++ b/pipelines/setup.yml
@@ -1,19 +1,19 @@
 ---
 resource_types:
   - name: s3-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/s3-resource
       tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
   - name: semver-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: ghcr.io/alphagov/paas/semver-resource
       tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
   - name: slack-notification-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
 
@@ -89,10 +89,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-release-ci
           params:
@@ -145,10 +145,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/terraform
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-release-ci
             - name: release-ci-tfstate
@@ -166,11 +166,12 @@ jobs:
               - -c
               - |
                 cp release-ci-tfstate/release-ci.tfstate updated-release-ci-tfstate/release-ci.tfstate
-                terraform init paas-release-ci/terraform
+
+                cd paas-release-ci/terraform || exit
+                terraform init
                 terraform apply \
                   -auto-approve=true \
-                  -state=updated-release-ci-tfstate/release-ci.tfstate \
-                  paas-release-ci/terraform
+                  -state="../../updated-release-ci-tfstate/release-ci.tfstate"
         ensure:
           put: release-ci-tfstate
           params:
@@ -190,10 +191,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/git-ssh
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: ssh-private-key
             - name: ssh-public-key
@@ -244,10 +245,10 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: ghcr.io/alphagov/paas/self-update-pipelines
-              tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+              tag: 540813b98e23f9865b33c206a840a8d5633287e9
           inputs:
             - name: paas-release-ci
           params:

--- a/scripts/fly_sync_and_login.sh
+++ b/scripts/fly_sync_and_login.sh
@@ -7,13 +7,8 @@ set -euo pipefail
   $FLY_CMD \
   $FLY_TARGET
 
-if [ "$USER" == "root" ] ; then
-  # We are running in Concourse
-  # Required env vars
-  # shellcheck disable=SC2086
-  : $CONCOURSE_WEB_USER \
-    $CONCOURSE_WEB_PASSWORD
-fi
+CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER:-}
+CONCOURSE_WEB_PASSWORD=${CONCOURSE_WEB_PASSWORD:-}
 
 fetch_fly() {
   echo "Downloading fly .."
@@ -34,17 +29,16 @@ fly_sync() {
 
 fly_login() {
   echo "Doing fly login .."
-  if [ "$USER" == "root" ] ; then
-    # We are running in Concourse
+  if [ -n "$CONCOURSE_WEB_USER" ] && [ -n "$CONCOURSE_WEB_PASSWORD" ] ; then
     $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_WEB_USER}" -p "${CONCOURSE_WEB_PASSWORD}"
   else
-    # We are running from our computer
+    # shellcheck disable=SC2016
+    echo '$CONCOURSE_WEB_USER and/or $CONCOURSE_WEB_PASSWORD not set - not attempting basic auth...'
     # Check if we are logged in, if we aren't then use the browser
     $FLY_CMD -t "${FLY_TARGET}" status || \
       $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}"
   fi
 }
-
 
 fly_is_runnable() {
   [ -x "${FLY_CMD}" ]


### PR DESCRIPTION
What
----

Noticed due to https://www.pivotaltracker.com/story/show/185500753 that we haven't updated the docker images used by the pipelines here in ... a long time.

To handle some of the changes, a few task alterations were needed, including using `registry-image` instead of `docker-image` as we have done almost everywhere else (in other repos).

~Depends on https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/283~

How to review
-------------

Tricky. Can possibly look at the release history of ci where this has been successfully deployed?
