### PR TITLE
180444788-Remove-UAA-release-pipeline

### DIFF
--- a/scripts/build-boshrelease-pipelines.sh
+++ b/scripts/build-boshrelease-pipelines.sh
@@ -59,7 +59,6 @@ setup_release_pipeline concourse          alphagov/paas-concourse-bosh-release  
 setup_release_pipeline oauth2-proxy       alphagov/paas-oauth2-proxy-boshrelease       gds_main
 setup_release_pipeline prometheus         alphagov/paas-prometheus-boshrelease         gds_main
 setup_release_pipeline routing            alphagov/paas-routing-release                gds_main
-setup_release_pipeline uaa                alphagov/paas-uaa-release                    gds_main
 
 echo Setting paas pipelines
 setup_release_pipeline cdn-broker         alphagov/paas-cdn-broker-boshrelease         main


### PR DESCRIPTION
Description:
- UAA has been unforked and we no longer use the [paas-uaa](https://github.com/alphagov/paas-uaa) and [paas-uaa-release](https://github.com/alphagov/paas-uaa-release) repositories hence this pipeline is now unnecessary
- See [here](https://github.com/alphagov/paas-cf/pull/2909) for the commit to unfork UAA

How to review
-------------

See `setup` in https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/setup and code review.
