### PR TITLE
BAU - Remove unnecessary Go module flag

### DIFF
--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -113,7 +113,6 @@ jobs:
                     PIVOTAL_TRACKER_PROJECT_ID: "${PIVOTAL_TRACKER_PROJECT_ID}"
                     PIVOTAL_TRACKER_API_TOKEN: "${PIVOTAL_TRACKER_API_TOKEN}"
                     PAGERDUTY_AUTHTOKEN: "${PAGERDUTY_AUTHTOKEN}"
-                    GO111MODULE: on
                     GOPACKAGENAME: github.com/alphagov/paas-rubbernecker
                     GOVERSION: go1.18
                 EOF


### PR DESCRIPTION
Description:
----
- The default behaviour is to turn Go modules on and we don't use `go get` to install binaries anymore
