### PR TITLE
BAU - Upgrade Rubbernecker buildpack to Go 1.20

### DIFF
--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -113,9 +113,8 @@ jobs:
                     PIVOTAL_TRACKER_PROJECT_ID: "${PIVOTAL_TRACKER_PROJECT_ID}"
                     PIVOTAL_TRACKER_API_TOKEN: "${PIVOTAL_TRACKER_API_TOKEN}"
                     PAGERDUTY_AUTHTOKEN: "${PAGERDUTY_AUTHTOKEN}"
-                    GO111MODULE: on
                     GOPACKAGENAME: github.com/alphagov/paas-rubbernecker
-                    GOVERSION: go1.18
+                    GOVERSION: go1.20
                 EOF
 
                 cf push rubbernecker -f manifest.yml --strategy rolling


### PR DESCRIPTION
Description:
----
- The default behaviour is to turn Go modules on and we don't use `go get` to install binaries anymore
- Upgrade buildpack to Go 1.20

How to review:
----
- See successful deployment at https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rubbernecker/jobs/deploy/builds/23
