### PR TITLE
[185517739] Build pipeline supports vendored releases

### DIFF
--- a/pipelines/build-release.yml
+++ b/pipelines/build-release.yml
@@ -106,6 +106,12 @@ jobs:
               - |
                 cd bosh-release-pr
 
+                if [ -x "./scripts/vendor_package.sh" ]; then
+                  ./scripts/vendor_package.sh
+                else
+                  echo "No vendor packaging is required."
+                fi
+
                 VERSION=0.0.$(date +%s)
                 export VERSION
                 bosh create-release \
@@ -178,6 +184,12 @@ jobs:
               - -c
               - |
                 cd bosh-release-repo
+
+                if [ -x "./scripts/vendor_package.sh" ]; then
+                  ./scripts/vendor_package.sh
+                else
+                  echo "No vendor packaging is required."
+                fi
 
                 VERSION=$(cat ../bosh-release-version/number)
                 export VERSION


### PR DESCRIPTION
What
----

Some builds will provide an executable shell script called `scripts/vendor_package.sh`. If that is the case the build pipeline will execute it to call `bosh vendor-package` against a bosh release. 
This should not interfere with other boshreleases.

How to review
-------------

- check the code
- use this commit against the build ci to verify that build releases are still working
 
Who can review
--------------

Engineers in the paas team