### PR TITLE
185827364 - Add deploy to London for Rubbernecker and redirect app

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A pipeline should be created for each Bosh release this repository is currently 
 
 ### Dev environments
 
-When you setup the pipelines in a dev environment they will be paused by default. You can manaully unpause the ones that you need to work on, but be aware that they will submit their results to GitHub pull requests.
+When you setup the pipelines in a dev environment they will be paused by default. You can manually unpause the ones that you need to work on, but be aware that they will submit their results to GitHub pull requests.
 
 * Run `DEPLOY_ENV=... make dev upload-cf-cli-secrets`. You can override the credentials used by setting `CF_USER` and `CF_PASSWORD`.
 * Run `CF_DEPLOY_ENV=... DEPLOY_ENV=... make dev pipelines`, where `CF_DEPLOY_ENV` is the environment name of your Cloud Foundry installation. CF_DEPLOY_ENV defaults to the DEPLOY_ENV.

--- a/pipelines/plain_pipelines/rubbernecker.yml
+++ b/pipelines/plain_pipelines/rubbernecker.yml
@@ -74,12 +74,13 @@ jobs:
             - name: paas-rubbernecker
           params:
             CF_API: https://api.((cf_system_domain))
+            CF_LONDON_API: https://api.london.((cf_system_domain))
             CF_USER: ((cf_user))
             CF_PASSWORD: ((cf_password))
+            CF_LONDON_USER: ((cf_london_user))
+            CF_LONDON_PASSWORD: ((cf_london_password))
             CF_ORG: govuk-paas
             CF_SPACE: tools
-            CF_APPS_DOMAIN: ((cf_apps_domain))
-            CF_SYSTEM_DOMAIN: ((cf_system_domain))
             PIVOTAL_TRACKER_PROJECT_ID: ((pivotal_tracker_project_id))
             PIVOTAL_TRACKER_API_TOKEN: ((pivotal_tracker_api_token))
             PAGERDUTY_AUTHTOKEN: ((pagerduty_authtoken))
@@ -97,6 +98,20 @@ jobs:
                   -a "${CF_API}" \
                   -u "${CF_USER}" \
                   -p "${CF_PASSWORD}" \
+                  -o "${CF_ORG}" \
+                  -s "${CF_SPACE}"
+
+                echo "Deploying Rubbernecker redirect to Ireland..."
+                cd redirect
+                cf push paas-rubbernecker-redirect -f manifest.yml --strategy rolling
+                cf logout
+                cd ..
+                
+                echo "Logging on to CloudFoundry London..."
+                cf login \
+                  -a "${CF_LONDON_API}" \
+                  -u "${CF_LONDON_USER}" \
+                  -p "${CF_LONDON_PASSWORD}" \
                   -o "${CF_ORG}" \
                   -s "${CF_SPACE}"
 

--- a/scripts/upload-secrets/upload-cf-cli-secrets.rb
+++ b/scripts/upload-secrets/upload-cf-cli-secrets.rb
@@ -9,6 +9,8 @@ aws_account = ENV["AWS_ACCOUNT"] || raise("AWS_ACCOUNT env var must be set")
 deploy_env = ENV["DEPLOY_ENV"] || raise("DEPLOY_ENV env var must be set")
 cf_user = ENV["CF_USER"] || `pass #{aws_account}_deployments/#{deploy_env}/cf_app_deployer_user`
 cf_password = ENV["CF_PASSWORD"] || `pass #{aws_account}_deployments/#{deploy_env}/cf_app_deployer_password`
+cf_london_user = ENV["CF_LONDON_USER"] || `pass #{aws_account}_deployments/#{deploy_env}/cf_app_london_deployer_user`
+cf_london_password = ENV["CF_LONDON_PASSWORD"] || `pass #{aws_account}_deployments/#{deploy_env}/cf_app_london_deployer_password`
 
 secrets = [
   {
@@ -20,6 +22,16 @@ secrets = [
     "name" => "/concourse/main/cf_password",
     "type" => "value",
     "value" => cf_password.chomp,
+  },
+  {
+    "name" => "/concourse/main/cf_london_user",
+    "type" => "value",
+    "value" => cf_london_user.chomp,
+  },
+  {
+    "name" => "/concourse/main/cf_london_password",
+    "type" => "value",
+    "value" => cf_london_password.chomp,
   },
 ]
 


### PR DESCRIPTION
Description:
----
- Deploy Rubbernecker to London using the CI user for London
- Remove the deployment of Rubbernecker to Ireland
- Deploy the redirect app to Ireland
- Remove CF_APPS_DOMAIN and CF_SYSTEM_DOMAIN as they are unused in this step
- Add CF_LONDON_USER and CF_LONDON_PASSWORD to secrets as this account is what CI uses to deploy to the London region

How to review
-------------

- Code review
- Visit [rubbernecker.cloudapps.digital](rubbernecker.cloudapps.digital) and verify the redirect
- See https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rubbernecker/jobs/test/builds/40 for a successful run


