### PR TITLE
Revert "[#185765129] Adding paas-cdn-broker for integration tests"

### DIFF
--- a/scripts/integration-test-pipelines.sh
+++ b/scripts/integration-test-pipelines.sh
@@ -60,4 +60,3 @@ setup_test_pipeline s3-broker alphagov paas-s3-broker main
 setup_test_pipeline sqs-broker alphagov paas-sqs-broker main
 setup_test_pipeline paas-service-broker-base alphagov paas-service-broker-base main
 setup_test_pipeline paas-prometheus-endpoints alphagov paas-prometheus-endpoints main
-setup_test_pipeline cdn-broker alphagov paas-cdn-broker main


### PR DESCRIPTION
Reverts alphagov/paas-release-ci#260

There is no cf in the build environment and consequently, integration tests for the cdn broker cannot be performed there.